### PR TITLE
Add speedometer styles and font options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,9 @@ Personnalisation complète des couleurs
 
 Disposition libre de chaque élément
 
+Choix de la police d’écriture
+
+Styles de compteur de vitesse (circulaire ou numérique)
+
 📸 Aperçu instantané de la première image avant rendu complet
+


### PR DESCRIPTION
## Summary
- allow choosing fonts with predefined options
- support selectable speedometer styles including new digital gauge

## Testing
- `python -m py_compile OverlayGPX_V1.py`


------
https://chatgpt.com/codex/tasks/task_b_68c683a2ca848324ab587a45778bacab