### PR TITLE
Add gauge styles, font options and OpenSnowMap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OverlayGPX est une application Python qui transforme un fichier GPX en une vidé
 ❤️ Profil de fréquence cardiaque
 
 ⚡ Jauge de vitesse en temps réel
+🔁 Plusieurs styles de jauge (circulaire, linéaire, compteur)
 
 📝 Bloc d’infos en direct : vitesse, altitude, heure, pente, allure, FC
 
@@ -26,7 +27,11 @@ OverlayGPX est une application Python qui transforme un fichier GPX en une vidé
 
 Choix de la résolution et des FPS
 
+Choix de la police et de sa taille
+
 Choix du style de carte et niveau de zoom (1 à 12)
+
+Support d'OpenSnowMap pour les fonds de carte
 
 Personnalisation complète des couleurs
 


### PR DESCRIPTION
## Summary
- Add OpenSnowMap background option
- Introduce circular, linear and numeric speedometers
- Allow choosing custom font and size for overlays

## Testing
- `python -m py_compile OverlayGPX_V1.py`


------
https://chatgpt.com/codex/tasks/task_b_68c689e807588324b69ea5225054b6f2