### PR TITLE
Add speed gauge styles, font options and OpenSnowMap tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OverlayGPX est une application Python qui transforme un fichier GPX en une vidé
 
   ✨ Fonctionnalités
 
-🗺️ Carte de fond avec trace GPS animée (OpenStreetMap, CyclOSM, IGN Satellite…)
+🗺️ Carte de fond avec trace GPS animée (OpenStreetMap, CyclOSM, IGN Satellite, OpenSnowMap…)
 ⛰️ Profil d’altitude
 
 🚴 Profil de vitesse
@@ -14,7 +14,8 @@ OverlayGPX est une application Python qui transforme un fichier GPX en une vidé
 
 ❤️ Profil de fréquence cardiaque
 
-⚡ Jauge de vitesse en temps réel
+⚡ Jauge de vitesse en temps réel (circulaire, linéaire ou compteur)
+✏️ Choix de la police d'écriture et de sa taille
 
 📝 Bloc d’infos en direct : vitesse, altitude, heure, pente, allure, FC
 


### PR DESCRIPTION
## Summary
- add OpenSnowMap tile provider
- support multiple speed gauge styles
- allow font selection and sizing in settings

## Testing
- `python -m py_compile OverlayGPX_V1.py`


------
https://chatgpt.com/codex/tasks/task_b_68c689e807588324b69ea5225054b6f2