### PR TITLE
Clamp tile zoom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Choix de la résolution et des FPS
 
 Choix du style de carte et niveau de zoom (1 à 12)
 
+Limitation automatique du zoom au niveau maximum supporté par chaque fournisseur de tuiles
+
 Personnalisation complète des couleurs
 
 Disposition libre de chaque élément


### PR DESCRIPTION
## Summary
- limit map tile zoom to each provider's supported maximum
- retry tile rendering with progressively lower zoom when tiles are missing
- document automatic zoom limiting for tile providers

## Testing
- `python -m py_compile OverlayGPX_V1.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6e33230a08324918d861d2729ca4b