### PR TITLE
Handle tile server zoom limits and user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ Personnalisation complète des couleurs
 Disposition libre de chaque élément
 
 📸 Aperçu instantané de la première image avant rendu complet
+
+## Fonds de carte
+
+Certains fournisseurs limitent le niveau de zoom ou imposent des règles d'accès.
+Le programme ajuste automatiquement le niveau de zoom pour éviter les tuiles manquantes
+et envoie un `User-Agent` explicite.
+
+- OpenSnowMap (relief et pistes) : zoom ≤ 18
+- OpenStreetMap, CyclOSM, IGN : zoom ≤ 19
+
+La couche "OpenSnowMap" correspond à un overlay de pistes transparent superposé au
+fond "OpenSnowMap Relief".


### PR DESCRIPTION
## Summary
- add per-provider max zoom levels and user-agent for tile requests
- combine OpenSnowMap pistes overlay with relief base and clamp zoom
- document tile provider zoom limits and overlay behavior

## Testing
- `python -m py_compile OverlayGPX_V1.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6e33230a08324918d861d2729ca4b