### PR TITLE
Remove duplicate compass rendering in generate_gpx_video

### DIFF
--- a/OverlayGPX_V1.py
+++ b/OverlayGPX_V1.py
@@ -1040,9 +1040,6 @@ def generate_gpx_video(
             frame_img.paste(view, (int(map_area.get("x", 0)), int(map_area.get("y", 0))))
             draw_north_arrow(frame_img, map_area, heading_deg, text_c)
 
-            draw_north_arrow(frame_img, map_area, heading_deg, text_c)
-
-
             # Profils & infos
             if elev_area.get("visible", False):
                 draw_graph(


### PR DESCRIPTION
## Summary
- remove the redundant draw_north_arrow invocation during frame composition so the compass renders only once per frame

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c920d26aa883249f3602693e91fa69