### PR TITLE
Respect du zoom en affichant la trace complète

### DIFF
--- a/OverlayGPX_V1.py
+++ b/OverlayGPX_V1.py
@@ -407,6 +407,96 @@ def prepare_track_arrays(
     }
 
 
+def to_local_time(dt: datetime, tz: pytz.BaseTzInfo) -> datetime:
+    """Ensure a datetime is timezone-aware in the provided tz."""
+
+    if dt.tzinfo is None:
+        return tz.localize(dt)
+    return dt.astimezone(tz)
+
+
+def _map_times_to_indices(track_seconds: np.ndarray, query_seconds: np.ndarray) -> np.ndarray:
+    """Associate each query time (s) to the nearest index within the track timeline."""
+
+    if track_seconds.size == 0:
+        return np.zeros(len(query_seconds), dtype=int)
+
+    insert_pos = np.searchsorted(track_seconds, query_seconds, side="left")
+    insert_pos = np.clip(insert_pos, 0, track_seconds.size)
+
+    right_idx = np.clip(insert_pos, 0, track_seconds.size - 1)
+    left_idx = np.clip(insert_pos - 1, 0, track_seconds.size - 1)
+
+    right_diff = np.abs(track_seconds[right_idx] - query_seconds)
+    left_diff = np.abs(query_seconds - track_seconds[left_idx])
+
+    use_left = left_diff <= right_diff
+    indices = np.where(use_left, left_idx, right_idx)
+    return np.maximum.accumulate(indices.astype(int))
+
+
+def build_full_track_context(
+    points: list[dict],
+    tz: pytz.BaseTzInfo,
+    clip_start_time: datetime,
+    interp_times: np.ndarray,
+):
+    """Prépare les données globales (trace complète) pour cartes et graphes."""
+
+    if not points:
+        return None
+
+    lats = np.array([pt["lat"] for pt in points], dtype=float)
+    lons = np.array([pt["lon"] for pt in points], dtype=float)
+    eles = np.array([pt["ele"] for pt in points], dtype=float)
+    hrs_raw = np.array([
+        (pt.get("hr") if pt.get("hr") is not None else np.nan) for pt in points
+    ], dtype=float)
+
+    local_times = [to_local_time(pt["time"], tz) for pt in points]
+    start_local = local_times[0]
+    end_local = local_times[-1]
+    track_seconds = np.array(
+        [(ts - start_local).total_seconds() for ts in local_times], dtype=float
+    )
+
+    if lats.size >= 2:
+        dists = haversine_np(lats[:-1], lons[:-1], lats[1:], lons[1:])
+        dt = np.diff(track_seconds)
+        seg_speeds = np.where(dt > 0, (dists / dt) * 3.6, 0.0)
+        if seg_speeds.size:
+            speeds = np.insert(seg_speeds, 0, seg_speeds[0])
+        else:
+            speeds = np.zeros(lats.shape[0], dtype=float)
+    else:
+        speeds = np.zeros(lats.shape[0], dtype=float)
+
+    pace = np.where(speeds > 0.05, 60.0 / speeds, np.inf)
+
+    clip_start_local = to_local_time(clip_start_time, tz)
+    offset_seconds = (clip_start_local - start_local).total_seconds()
+    frame_global_seconds = offset_seconds + np.asarray(interp_times, dtype=float)
+    progress_indices = _map_times_to_indices(track_seconds, frame_global_seconds)
+
+    clip_start_index = int(progress_indices[0]) if progress_indices.size else 0
+    clip_end_index = int(progress_indices[-1]) if progress_indices.size else clip_start_index
+
+    return {
+        "lats": lats,
+        "lons": lons,
+        "eles": eles,
+        "speeds": speeds,
+        "pace": pace,
+        "hrs": hrs_raw,
+        "track_seconds": track_seconds,
+        "start_local": start_local,
+        "end_local": end_local,
+        "progress_indices": progress_indices,
+        "clip_start_index": clip_start_index,
+        "clip_end_index": clip_end_index,
+    }
+
+
 def format_hms(seconds: int) -> str:
     """Format seconds into H:MM:SS."""
     return str(timedelta(seconds=int(max(0, seconds))))
@@ -687,17 +777,34 @@ def draw_graph_progress_overlay(
     base_color,
     current_point_color,
     point_size: int = 4,
+    progress_indices: np.ndarray | list[int] | None = None,
+    clip_start_index: int | None = None,
 ) -> None:
     """Dessine la portion courante et le point actuel sur un graphe pré-dessiné."""
 
     if not path_coords:
         return
 
-    idx = max(0, min(current_index, len(path_coords) - 1))
-    if idx >= 1:
-        draw.line(path_coords[: idx + 1], fill=base_color, width=5)
+    if progress_indices is not None and len(progress_indices):
+        idx_src = max(0, min(current_index, len(progress_indices) - 1))
+        idx_val = int(progress_indices[idx_src])
+        idx = max(0, min(idx_val, len(path_coords) - 1))
+        start_idx = clip_start_index if clip_start_index is not None else int(progress_indices[0])
+        start_idx = max(0, min(start_idx, len(path_coords) - 1))
 
-    cx, cy = path_coords[idx]
+        if len(path_coords) == 1:
+            cx, cy = path_coords[0]
+        else:
+            if idx >= start_idx and idx > 0:
+                seg_start = start_idx if idx >= start_idx else 0
+                draw.line(path_coords[seg_start : idx + 1], fill=base_color, width=5)
+            cx, cy = path_coords[idx]
+    else:
+        idx = max(0, min(current_index, len(path_coords) - 1))
+        if idx >= 1:
+            draw.line(path_coords[: idx + 1], fill=base_color, width=5)
+        cx, cy = path_coords[idx]
+
     draw.ellipse((cx - point_size, cy - point_size, cx + point_size, cy + point_size), fill=current_point_color)
 
 
@@ -706,12 +813,15 @@ def prepare_graph_layers(
     font,
     text_color,
     point_color,
-    graph_specs: list[tuple[dict, list[tuple[int, int]], float, float, str, str, tuple[int, int, int]]],
+    graph_specs,
 ) -> list[dict]:
     """Prépare les couches de graphes (fond pré-rendu + méta-données)."""
 
     layers: list[dict] = []
-    for area, path_coords, min_val, max_val, title, unit, base_color in graph_specs:
+    for spec in graph_specs:
+        if len(spec) < 7:
+            continue
+        area, path_coords, min_val, max_val, title, unit, base_color, *extra = spec
         if not is_area_visible(area):
             continue
         background = create_graph_background_image(
@@ -726,6 +836,12 @@ def prepare_graph_layers(
             base_color,
             text_color,
         )
+        progress_indices = None
+        clip_start_index = None
+        if extra:
+            progress_indices = extra[0]
+            if len(extra) >= 2:
+                clip_start_index = extra[1]
         layers.append(
             {
                 "area": area,
@@ -738,6 +854,8 @@ def prepare_graph_layers(
                 "point_color": point_color,
                 "background": background,
                 "point_size": 4,
+                "progress_indices": progress_indices,
+                "clip_start_index": clip_start_index,
             }
         )
     return layers
@@ -959,12 +1077,51 @@ def draw_digital_speedometer(draw, speed, speed_min, speed_max, draw_area, font,
     pivot_r = max(3, int(radius * 0.04))
     draw.ellipse([cx - pivot_r, cy - pivot_r, cx + pivot_r, cy + pivot_r], fill=(255, 255, 255))
 
-def draw_info_text(draw, speed, altitude, slope, current_time, draw_area, font, tz, text_color):
-    display_time = current_time.astimezone(tz).strftime("%H:%M:%S")
+def draw_info_text(
+    draw,
+    speed,
+    altitude,
+    slope,
+    current_time,
+    draw_area,
+    font,
+    tz,
+    text_color,
+    elapsed_seconds: float | None = None,
+    total_seconds: float | None = None,
+    time_label: str = "Temps",
+    duration_label: str = "Durée",
+):
     draw.text((draw_area["x"], draw_area["y"]), f"Vitesse : {speed:.0f} km/h", font=font, fill=text_color)
-    draw.text((draw_area["x"], draw_area["y"] + FONT_SIZE_LARGE + 10), f"Altitude : {altitude:.0f} m", font=font, fill=text_color)
-    draw.text((draw_area["x"], draw_area["y"] + 2 * (FONT_SIZE_LARGE + 10)), f"Heure : {display_time}", font=font, fill=text_color)
-    draw.text((draw_area["x"], draw_area["y"] + 3 * (FONT_SIZE_LARGE + 10)), f"Pente : {slope:.1f} %", font=font, fill=text_color)
+    draw.text(
+        (draw_area["x"], draw_area["y"] + FONT_SIZE_LARGE + 10),
+        f"Altitude : {altitude:.0f} m",
+        font=font,
+        fill=text_color,
+    )
+
+    if elapsed_seconds is None:
+        display_time = current_time.astimezone(tz).strftime("%H:%M:%S")
+        time_line = f"Heure : {display_time}"
+    else:
+        elapsed_text = format_hms(int(max(0, round(elapsed_seconds))))
+        time_line = f"{time_label} : {elapsed_text}"
+        if total_seconds is not None:
+            total_text = format_hms(int(max(0, round(total_seconds))))
+            time_line += f" / {duration_label} : {total_text}"
+
+    draw.text(
+        (draw_area["x"], draw_area["y"] + 2 * (FONT_SIZE_LARGE + 10)),
+        time_line,
+        font=font,
+        fill=text_color,
+    )
+    draw.text(
+        (draw_area["x"], draw_area["y"] + 3 * (FONT_SIZE_LARGE + 10)),
+        f"Pente : {slope:.1f} %",
+        font=font,
+        fill=text_color,
+    )
 
 # --- AJOUT : texte allure & FC (dessiné sous les 3 lignes existantes) ---
 def draw_pace_hr_text(draw, pace_minpk, hr_bpm, draw_area, font, text_color):
@@ -1154,6 +1311,7 @@ def generate_gpx_video(
     color_configs=None,
     map_style: str = "CyclOSM (FR)",
     zoom_level_ui: int = 8,      # 1..12 (8 = ajusté)
+    show_full_track: bool = False,
     smoothing_seconds: float = DEFAULT_GRAPH_SMOOTHING_SECONDS,
     progress_callback=None,
 ) -> bool:
@@ -1188,7 +1346,7 @@ def generate_gpx_video(
 
 
     # GPX
-    points, gpx_start, _ = parse_gpx(gpx_filename)
+    points, gpx_start, gpx_end = parse_gpx(gpx_filename)
     if not points:
         print("Aucun point GPX.")
         return False
@@ -1220,6 +1378,12 @@ def generate_gpx_video(
         clip_duration,
         fps,
         smoothing_seconds,
+    )
+
+    full_context = (
+        build_full_track_context(points, tz, start_time, data["interp_times"])
+        if show_full_track
+        else None
     )
 
     total_frames = data["total_frames"]
@@ -1268,29 +1432,62 @@ def generate_gpx_video(
         print("Zone carte non visible ou dimensions nulles.")
         return False
 
-    # BBox brute & centre
-    lat_min_raw = float(np.min(lats)); lat_max_raw = float(np.max(lats))
-    lon_min_raw = float(np.min(lons)); lon_max_raw = float(np.max(lons))
+    full_lats = full_context["lats"] if full_context else None
+    full_lons = full_context["lons"] if full_context else None
+
+    lat_min_raw = float(np.min(lats))
+    lat_max_raw = float(np.max(lats))
+    lon_min_raw = float(np.min(lons))
+    lon_max_raw = float(np.max(lons))
     lat_c = (lat_min_raw + lat_max_raw) * 0.5
     lon_c = (lon_min_raw + lon_max_raw) * 0.5
 
     # Profils (altitude & vitesse)
-    elev_min = float(np.min(interp_eles))
-    elev_max = float(np.max(interp_eles))
-    elev_tf = GraphTransformer(elev_min, elev_max, elev_area)
-    elev_path = [elev_tf.to_xy(i, val, len(interp_eles)) for i, val in enumerate(interp_eles)]
+    if full_context:
+        graph_elev_series = full_context["eles"]
+        graph_speed_series = full_context["speeds"]
+        graph_pace_series = full_context["pace"]
+        graph_hr_series = full_context["hrs"]
+        progress_indices = full_context["progress_indices"]
+        clip_start_index = full_context["clip_start_index"]
+    else:
+        graph_elev_series = interp_eles
+        graph_speed_series = interp_speeds
+        graph_pace_series = interp_pace
+        graph_hr_series = interp_hrs
+        progress_indices = None
+        clip_start_index = None
 
-    speed_min_val = float(np.min(interp_speeds))
-    speed_max_val = float(np.max(interp_speeds))
-    speed_min, speed_max = auto_speed_bounds(interp_speeds)
+    elev_min = float(np.min(graph_elev_series)) if graph_elev_series.size else 0.0
+    elev_max = float(np.max(graph_elev_series)) if graph_elev_series.size else 0.0
+    elev_tf = GraphTransformer(elev_min, elev_max, elev_area)
+    elev_path = [
+        elev_tf.to_xy(i, float(val), len(graph_elev_series))
+        for i, val in enumerate(graph_elev_series)
+    ]
+
+    speed_min_val = float(np.min(graph_speed_series)) if graph_speed_series.size else 0.0
+    speed_max_val = float(np.max(graph_speed_series)) if graph_speed_series.size else 0.0
+    speed_min, speed_max = (
+        auto_speed_bounds(graph_speed_series)
+        if graph_speed_series.size
+        else (0.0, 10.0)
+    )
 
     speed_tf = GraphTransformer(speed_min, speed_max, speed_area)
-    speed_path = [speed_tf.to_xy(i, val, len(interp_speeds)) for i, val in enumerate(interp_speeds)]
+    speed_path = [
+        speed_tf.to_xy(i, float(val), len(graph_speed_series))
+        for i, val in enumerate(graph_speed_series)
+    ]
 
     # --- AJOUT : profils Allure & Cardio ---
 
     pace_min, pace_max = PACE_GRAPH_MIN, PACE_GRAPH_MAX
-    pace_tf = GraphTransformer(pace_min, pace_max, pace_area if pace_area else {"x":0,"y":0,"width":1,"height":1})
+    pace_tf = GraphTransformer(
+        pace_min,
+        pace_max,
+        pace_area if pace_area else {"x": 0, "y": 0, "width": 1, "height": 1},
+    )
     pace_path = [
         pace_tf.to_xy(
             i,
@@ -1299,20 +1496,27 @@ def generate_gpx_video(
                 if not np.isfinite(val)
                 else max(pace_min, min(float(val), pace_max))
             ),
-            len(interp_pace),
+            len(graph_pace_series),
         )
-        for i, val in enumerate(interp_pace)
+        for i, val in enumerate(graph_pace_series)
     ]
 
-
-    has_hr = np.isfinite(interp_hrs).sum() >= 1
+    hr_array = np.asarray(graph_hr_series, dtype=float)
+    has_hr = np.isfinite(hr_array).sum() >= 1
     if has_hr:
-        hr_vals = interp_hrs[np.isfinite(interp_hrs)]
+        hr_vals = hr_array[np.isfinite(hr_array)]
         hr_min, hr_max = float(np.min(hr_vals)), float(np.max(hr_vals))
     else:
         hr_min, hr_max = 0.0, 1.0
-    hr_tf = GraphTransformer(hr_min, hr_max if hr_max > hr_min else (hr_min + 1.0), hr_area if hr_area else {"x":0,"y":0,"width":1,"height":1})
-    hr_path = [hr_tf.to_xy(i, (val if np.isfinite(val) else hr_min), len(interp_hrs)) for i, val in enumerate(interp_hrs)]
+    hr_tf = GraphTransformer(
+        hr_min,
+        hr_max if hr_max > hr_min else (hr_min + 1.0),
+        hr_area if hr_area else {"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    hr_path = [
+        hr_tf.to_xy(i, (val if np.isfinite(val) else hr_min), len(hr_array))
+        for i, val in enumerate(hr_array)
+    ]
 
     graph_specs = [
         (elev_area, elev_path, elev_min, elev_max, "Altitude", "m", alt_path_c),
@@ -1321,6 +1525,10 @@ def generate_gpx_video(
     ]
     if has_hr:
         graph_specs.append((hr_area, hr_path, hr_min, hr_max, "FC", "bpm", hr_path_c))
+    if progress_indices is not None and len(progress_indices):
+        graph_specs = [
+            spec + (progress_indices, clip_start_index) for spec in graph_specs
+        ]
     graph_layers = prepare_graph_layers(
         resolution,
         font_graph,
@@ -1328,6 +1536,24 @@ def generate_gpx_video(
         graph_current_point_c,
         graph_specs,
     )
+
+    if full_context:
+        gpx_start_local = full_context["start_local"]
+        gpx_end_local = full_context["end_local"]
+        time_reference = gpx_start_local
+        time_label = "Temps GPX"
+        duration_label = "Durée GPX"
+        total_duration_seconds = max(
+            0,
+            int(round((gpx_end_local - gpx_start_local).total_seconds())),
+        )
+    else:
+        gpx_start_local = None
+        gpx_end_local = None
+        time_reference = start_time
+        time_label = "Temps clip"
+        duration_label = "Durée clip"
+        total_duration_seconds = max(0, int(round(clip_duration)))
 
     try:
 
@@ -1340,12 +1566,21 @@ def generate_gpx_video(
         zoom = max(1, min(19, base_zoom + (zoom_level_ui - 8)))
 
         # Positions "monde" au zoom choisi
-        xs_world, ys_world = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
+        xs_world_selected, ys_world_selected = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
+        xs_world_clip, ys_world_clip = lonlat_to_pixel_np(lons, lats, zoom)
 
         # Etendue, marge et image "large"
-        x_min = float(np.min(xs_world)); x_max = float(np.max(xs_world))
-        y_min = float(np.min(ys_world)); y_max = float(np.max(ys_world))
+        x_min = float(np.min(xs_world_clip)); x_max = float(np.max(xs_world_clip))
+        y_min = float(np.min(ys_world_clip)); y_max = float(np.max(ys_world_clip))
         track_w = x_max - x_min; track_h = y_max - y_min
+
+        xs_world_full = ys_world_full = None
+        if full_lats is not None and full_lons is not None:
+            xs_world_full, ys_world_full = lonlat_to_pixel_np(full_lons, full_lats, zoom)
+            full_x_min = float(np.min(xs_world_full)); full_x_max = float(np.max(xs_world_full))
+            full_y_min = float(np.min(ys_world_full)); full_y_max = float(np.max(ys_world_full))
+            track_w = max(track_w, full_x_max - full_x_min)
+            track_h = max(track_h, full_y_max - full_y_min)
 
         patch_w = int(math.ceil(mw * PATCH_FACTOR))
         patch_h = int(math.ceil(mh * PATCH_FACTOR))
@@ -1369,10 +1604,19 @@ def generate_gpx_video(
             base_map_img_large = Image.new("RGB", (width_large, height_large), bg_c)
 
         # Trace dans le repère "large"
-        x_full = xs_world - x0_world
-        y_full = ys_world - y0_world
-        global_xy = np.column_stack((np.rint(x_full).astype(int), np.rint(y_full).astype(int)))
+        x_full_selected = xs_world_selected - x0_world
+        y_full_selected = ys_world_selected - y0_world
+        global_xy = np.column_stack((np.rint(x_full_selected).astype(int), np.rint(y_full_selected).astype(int)))
         local_xy_buffer = np.empty_like(global_xy)
+
+        if xs_world_full is not None and ys_world_full is not None:
+            x_full_all = xs_world_full - x0_world
+            y_full_all = ys_world_full - y0_world
+            global_xy_full = np.column_stack((np.rint(x_full_all).astype(int), np.rint(y_full_all).astype(int)))
+            full_local_xy_buffer = np.empty_like(global_xy_full)
+        else:
+            global_xy_full = None
+            full_local_xy_buffer = None
 
         # Tête lissée (pour rotation)
         if total_frames == 0:
@@ -1381,10 +1625,10 @@ def generate_gpx_video(
             dx = np.zeros(total_frames, dtype=float)
             dy = np.zeros(total_frames, dtype=float)
             if total_frames > 1:
-                dx[:-1] = np.diff(x_full)
-                dy[:-1] = np.diff(y_full)
-                dx[-1] = x_full[-1] - x_full[-2]
-                dy[-1] = y_full[-1] - y_full[-2]
+                dx[:-1] = np.diff(x_full_selected)
+                dy[:-1] = np.diff(y_full_selected)
+                dx[-1] = x_full_selected[-1] - x_full_selected[-2]
+                dy[-1] = y_full_selected[-1] - y_full_selected[-2]
             headings = np.zeros(total_frames, dtype=float)
             non_zero = (np.abs(dx) > 1e-9) | (np.abs(dy) > 1e-9)
             headings[non_zero] = np.arctan2(dx[non_zero], -dy[non_zero])
@@ -1410,7 +1654,7 @@ def generate_gpx_video(
             draw = ImageDraw.Draw(frame_img)
 
             # Patch centré sur le point courant
-            xc = float(x_full[frame_idx]); yc = float(y_full[frame_idx])
+            xc = float(x_full_selected[frame_idx]); yc = float(y_full_selected[frame_idx])
             patch_left = int(round(xc - patch_w / 2.0))
             patch_top  = int(round(yc - patch_h / 2.0))
             patch_img = Image.new("RGB", (patch_w, patch_h), bg_c)
@@ -1427,10 +1671,18 @@ def generate_gpx_video(
 
             # Trace + progression + point (dans le patch)
             pdraw = ImageDraw.Draw(patch_img)
+            if global_xy_full is not None and full_local_xy_buffer is not None:
+                np.subtract(global_xy_full[:, 0], patch_left, out=full_local_xy_buffer[:, 0])
+                np.subtract(global_xy_full[:, 1], patch_top, out=full_local_xy_buffer[:, 1])
+                full_local_xy_list = [(int(pt[0]), int(pt[1])) for pt in full_local_xy_buffer]
+                if len(full_local_xy_list) >= 2:
+                    pdraw.line(full_local_xy_list, fill=map_path_c, width=2)
+
             np.subtract(global_xy[:, 0], patch_left, out=local_xy_buffer[:, 0])
             np.subtract(global_xy[:, 1], patch_top, out=local_xy_buffer[:, 1])
             local_xy_list = [(int(pt[0]), int(pt[1])) for pt in local_xy_buffer]
-            pdraw.line(local_xy_list, fill=map_path_c, width=3)
+            if len(local_xy_list) >= 2:
+                pdraw.line(local_xy_list, fill=map_path_c, width=3)
             pdraw.line(local_xy_list[: frame_idx + 1], fill=map_current_path_c, width=4)
             cxp, cyp = local_xy_buffer[frame_idx]
             r = 6
@@ -1470,6 +1722,8 @@ def generate_gpx_video(
                     layer["base_color"],
                     layer["point_color"],
                     layer["point_size"],
+                    progress_indices=layer.get("progress_indices"),
+                    clip_start_index=layer.get("clip_start_index"),
                 )
 
             if gauge_circ_area.get("visible", False):
@@ -1510,12 +1764,28 @@ def generate_gpx_video(
                 draw_compass_tape(draw, heading_deg, compass_area, font_medium, text_c)
 
             if info_area.get("visible", False):
-                draw_info_text(draw,
-                               float(interp_speeds[frame_idx]),
-                               float(interp_eles[frame_idx]),
-                               float(interp_slopes[frame_idx]),
-                               start_time + timedelta(seconds=float(interp_times[frame_idx])),
-                               info_area, font_medium, tz, text_c)
+                current_dt = start_time + timedelta(seconds=float(interp_times[frame_idx]))
+                elapsed_seconds = None
+                if time_reference is not None:
+                    try:
+                        elapsed_seconds = max(0.0, (current_dt - time_reference).total_seconds())
+                    except Exception:
+                        elapsed_seconds = None
+                draw_info_text(
+                    draw,
+                    float(interp_speeds[frame_idx]),
+                    float(interp_eles[frame_idx]),
+                    float(interp_slopes[frame_idx]),
+                    current_dt,
+                    info_area,
+                    font_medium,
+                    tz,
+                    text_c,
+                    elapsed_seconds=elapsed_seconds,
+                    total_seconds=total_duration_seconds,
+                    time_label=time_label,
+                    duration_label=duration_label,
+                )
                 # --- Texte Allure & FC supplémentaires ---
                 pace_now = float(interp_pace[frame_idx])
                 hr_now = float(interp_hrs[frame_idx]) if np.isfinite(interp_hrs[frame_idx]) else None
@@ -1553,6 +1823,7 @@ def render_first_frame_image(
     color_configs: dict | None = None,
     map_style: str = "CyclOSM (FR)",
     zoom_level_ui: int = 8,
+    show_full_track: bool = False,
     smoothing_seconds: float = DEFAULT_GRAPH_SMOOTHING_SECONDS,
 ):
     # --- Constantes identiques à celles de generate_gpx_video ---
@@ -1582,7 +1853,7 @@ def render_first_frame_image(
     text_c = (color_configs.get("text", TEXT_COLOR) if color_configs else TEXT_COLOR)
     gauge_bg_c = (color_configs.get("gauge_background", GAUGE_BG_COLOR) if color_configs else GAUGE_BG_COLOR)
 
-    points, gpx_start, _ = parse_gpx(gpx_filename)
+    points, gpx_start, gpx_end = parse_gpx(gpx_filename)
     if not points:
         raise ValueError("Aucun point GPX.")
     if gpx_start is None:
@@ -1607,6 +1878,11 @@ def render_first_frame_image(
         clip_duration,
         fps,
         smoothing_seconds,
+    )
+    full_context = (
+        build_full_track_context(points, tz, start_time, data["interp_times"])
+        if show_full_track
+        else None
     )
     total_frames = data["total_frames"]
     interp_times = data["interp_times"]
@@ -1635,25 +1911,59 @@ def render_first_frame_image(
     if not map_area.get("visible", False) or mw <= 0 or mh <= 0:
         raise ValueError("Zone carte non visible ou dimensions nulles.")
 
-    lat_min_raw = float(np.min(lats)); lat_max_raw = float(np.max(lats))
-    lon_min_raw = float(np.min(lons)); lon_max_raw = float(np.max(lons))
+    full_lats = full_context["lats"] if full_context else None
+    full_lons = full_context["lons"] if full_context else None
+
+    lat_min_raw = float(np.min(lats))
+    lat_max_raw = float(np.max(lats))
+    lon_min_raw = float(np.min(lons))
+    lon_max_raw = float(np.max(lons))
     lat_c = (lat_min_raw + lat_max_raw) * 0.5
     lon_c = (lon_min_raw + lon_max_raw) * 0.5
 
-    elev_min = float(np.min(interp_eles))
-    elev_max = float(np.max(interp_eles))
-    elev_tf = GraphTransformer(elev_min, elev_max, elev_area)
-    elev_path = [elev_tf.to_xy(i, val, len(interp_eles)) for i, val in enumerate(interp_eles)]
+    if full_context:
+        graph_elev_series = full_context["eles"]
+        graph_speed_series = full_context["speeds"]
+        graph_pace_series = full_context["pace"]
+        graph_hr_series = full_context["hrs"]
+        progress_indices = full_context["progress_indices"]
+        clip_start_index = full_context["clip_start_index"]
+    else:
+        graph_elev_series = interp_eles
+        graph_speed_series = interp_speeds
+        graph_pace_series = interp_pace
+        graph_hr_series = interp_hrs
+        progress_indices = None
+        clip_start_index = None
 
-    speed_min_val = float(np.min(interp_speeds))
-    speed_max_val = float(np.max(interp_speeds))
-    speed_min, speed_max = auto_speed_bounds(interp_speeds)
+    elev_min = float(np.min(graph_elev_series)) if graph_elev_series.size else 0.0
+    elev_max = float(np.max(graph_elev_series)) if graph_elev_series.size else 0.0
+    elev_tf = GraphTransformer(elev_min, elev_max, elev_area)
+    elev_path = [
+        elev_tf.to_xy(i, float(val), len(graph_elev_series))
+        for i, val in enumerate(graph_elev_series)
+    ]
+
+    speed_min_val = float(np.min(graph_speed_series)) if graph_speed_series.size else 0.0
+    speed_max_val = float(np.max(graph_speed_series)) if graph_speed_series.size else 0.0
+    speed_min, speed_max = (
+        auto_speed_bounds(graph_speed_series)
+        if graph_speed_series.size
+        else (0.0, 10.0)
+    )
 
     speed_tf = GraphTransformer(speed_min, speed_max, speed_area)
-    speed_path = [speed_tf.to_xy(i, val, len(interp_speeds)) for i, val in enumerate(interp_speeds)]
+    speed_path = [
+        speed_tf.to_xy(i, float(val), len(graph_speed_series))
+        for i, val in enumerate(graph_speed_series)
+    ]
 
     pace_min, pace_max = PACE_GRAPH_MIN, PACE_GRAPH_MAX
-    pace_tf = GraphTransformer(pace_min, pace_max, pace_area if pace_area else {"x":0,"y":0,"width":1,"height":1})
+    pace_tf = GraphTransformer(
+        pace_min,
+        pace_max,
+        pace_area if pace_area else {"x": 0, "y": 0, "width": 1, "height": 1},
+    )
     pace_path = [
         pace_tf.to_xy(
             i,
@@ -1662,19 +1972,27 @@ def render_first_frame_image(
                 if not np.isfinite(val)
                 else max(pace_min, min(float(val), pace_max))
             ),
-            len(interp_pace),
+            len(graph_pace_series),
         )
-        for i, val in enumerate(interp_pace)
+        for i, val in enumerate(graph_pace_series)
     ]
 
-    has_hr = np.isfinite(interp_hrs).sum() >= 1
+    hr_array = np.asarray(graph_hr_series, dtype=float)
+    has_hr = np.isfinite(hr_array).sum() >= 1
     if has_hr:
-        hr_vals = interp_hrs[np.isfinite(interp_hrs)]
+        hr_vals = hr_array[np.isfinite(hr_array)]
         hr_min, hr_max = float(np.min(hr_vals)), float(np.max(hr_vals))
     else:
         hr_min, hr_max = 0.0, 1.0
-    hr_tf = GraphTransformer(hr_min, hr_max if hr_max > hr_min else (hr_min + 1.0), hr_area if hr_area else {"x":0,"y":0,"width":1,"height":1})
-    hr_path = [hr_tf.to_xy(i, (val if np.isfinite(val) else hr_min), len(interp_hrs)) for i, val in enumerate(interp_hrs)]
+    hr_tf = GraphTransformer(
+        hr_min,
+        hr_max if hr_max > hr_min else (hr_min + 1.0),
+        hr_area if hr_area else {"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    hr_path = [
+        hr_tf.to_xy(i, (val if np.isfinite(val) else hr_min), len(hr_array))
+        for i, val in enumerate(hr_array)
+    ]
 
     graph_specs = [
         (elev_area, elev_path, elev_min, elev_max, "Altitude", "m", alt_path_c),
@@ -1683,6 +2001,10 @@ def render_first_frame_image(
     ]
     if has_hr:
         graph_specs.append((hr_area, hr_path, hr_min, hr_max, "FC", "bpm", hr_path_c))
+    if progress_indices is not None and len(progress_indices):
+        graph_specs = [
+            spec + (progress_indices, clip_start_index) for spec in graph_specs
+        ]
     graph_layers = prepare_graph_layers(
         resolution,
         font_graph,
@@ -1690,6 +2012,22 @@ def render_first_frame_image(
         graph_current_point_c,
         graph_specs,
     )
+
+    if full_context:
+        gpx_start_local = full_context["start_local"]
+        gpx_end_local = full_context["end_local"]
+        time_reference = gpx_start_local
+        time_label = "Temps GPX"
+        duration_label = "Durée GPX"
+        total_duration_seconds = max(
+            0,
+            int(round((gpx_end_local - gpx_start_local).total_seconds())),
+        )
+    else:
+        time_reference = start_time
+        time_label = "Temps clip"
+        duration_label = "Durée clip"
+        total_duration_seconds = max(0, int(round(clip_duration)))
 
     frame_img = Image.new("RGB", resolution, bg_c)
     draw = ImageDraw.Draw(frame_img)
@@ -1702,11 +2040,20 @@ def render_first_frame_image(
         base_zoom = bbox_fit_zoom(est_w, est_h, lon_min_raw, lat_min_raw, lon_max_raw, lat_max_raw, padding_px=20)
         zoom = max(1, min(19, base_zoom + (zoom_level_ui - 8)))
 
-        xs_world, ys_world = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
+        xs_world_selected, ys_world_selected = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
+        xs_world_clip, ys_world_clip = lonlat_to_pixel_np(lons, lats, zoom)
 
-        x_min = float(np.min(xs_world)); x_max = float(np.max(xs_world))
-        y_min = float(np.min(ys_world)); y_max = float(np.max(ys_world))
+        x_min = float(np.min(xs_world_clip)); x_max = float(np.max(xs_world_clip))
+        y_min = float(np.min(ys_world_clip)); y_max = float(np.max(ys_world_clip))
         track_w = x_max - x_min; track_h = y_max - y_min
+
+        xs_world_full = ys_world_full = None
+        if full_lats is not None and full_lons is not None:
+            xs_world_full, ys_world_full = lonlat_to_pixel_np(full_lons, full_lats, zoom)
+            full_x_min = float(np.min(xs_world_full)); full_x_max = float(np.max(xs_world_full))
+            full_y_min = float(np.min(ys_world_full)); full_y_max = float(np.max(ys_world_full))
+            track_w = max(track_w, full_x_max - full_x_min)
+            track_h = max(track_h, full_y_max - full_y_min)
 
 
         patch_w = int(math.ceil(mw * PATCH_FACTOR))
@@ -1727,19 +2074,28 @@ def render_first_frame_image(
         except Exception:
             base_map_img_large = Image.new("RGB", (width_large, height_large), bg_c)
 
-        x_full = xs_world - x0_world
-        y_full = ys_world - y0_world
-        global_xy = np.column_stack((np.rint(x_full).astype(int), np.rint(y_full).astype(int)))
+        x_full_selected = xs_world_selected - x0_world
+        y_full_selected = ys_world_selected - y0_world
+        global_xy = np.column_stack((np.rint(x_full_selected).astype(int), np.rint(y_full_selected).astype(int)))
         local_xy_buffer = np.empty_like(global_xy)
+
+        if xs_world_full is not None and ys_world_full is not None:
+            x_full_all = xs_world_full - x0_world
+            y_full_all = ys_world_full - y0_world
+            global_xy_full = np.column_stack((np.rint(x_full_all).astype(int), np.rint(y_full_all).astype(int)))
+            full_local_xy_buffer = np.empty_like(global_xy_full)
+        else:
+            global_xy_full = None
+            full_local_xy_buffer = None
 
         headings = []
         for i in range(total_frames):
             if i < total_frames - 1:
-                dx = x_full[i + 1] - x_full[i]
-                dy = y_full[i + 1] - y_full[i]
+                dx = x_full_selected[i + 1] - x_full_selected[i]
+                dy = y_full_selected[i + 1] - y_full_selected[i]
             else:
-                dx = x_full[i] - x_full[i - 1]
-                dy = y_full[i] - y_full[i - 1]
+                dx = x_full_selected[i] - x_full_selected[i - 1]
+                dy = y_full_selected[i] - y_full_selected[i - 1]
             if abs(dx) > 1e-9 or abs(dy) > 1e-9:
                 headings.append(math.atan2(dx, -dy))
             else:
@@ -1755,8 +2111,8 @@ def render_first_frame_image(
             avg = np.mean(complex_raw[a:b])
             smoothed_angles.append(math.atan2(avg.imag, avg.real))
 
-        xc = float(x_full[0])
-        yc = float(y_full[0])
+        xc = float(x_full_selected[0])
+        yc = float(y_full_selected[0])
         patch_left = int(round(xc - patch_w / 2.0))
         patch_top = int(round(yc - patch_h / 2.0))
         patch_img = Image.new("RGB", (patch_w, patch_h), bg_c)
@@ -1772,10 +2128,17 @@ def render_first_frame_image(
             patch_img.paste(crop, (dest_x, dest_y))
 
         pdraw = ImageDraw.Draw(patch_img)
+        if global_xy_full is not None and full_local_xy_buffer is not None:
+            np.subtract(global_xy_full[:, 0], patch_left, out=full_local_xy_buffer[:, 0])
+            np.subtract(global_xy_full[:, 1], patch_top, out=full_local_xy_buffer[:, 1])
+            full_local_xy_list = [(int(pt[0]), int(pt[1])) for pt in full_local_xy_buffer]
+            if len(full_local_xy_list) >= 2:
+                pdraw.line(full_local_xy_list, fill=map_path_c, width=2)
         np.subtract(global_xy[:, 0], patch_left, out=local_xy_buffer[:, 0])
         np.subtract(global_xy[:, 1], patch_top, out=local_xy_buffer[:, 1])
         local_xy_list = [(int(pt[0]), int(pt[1])) for pt in local_xy_buffer]
-        pdraw.line(local_xy_list, fill=map_path_c, width=3)
+        if len(local_xy_list) >= 2:
+            pdraw.line(local_xy_list, fill=map_path_c, width=3)
         pdraw.line(local_xy_list[:1], fill=map_current_path_c, width=4)
         cxp, cyp = local_xy_buffer[0]
         r = 6
@@ -1810,6 +2173,8 @@ def render_first_frame_image(
             layer["base_color"],
             layer["point_color"],
             layer["point_size"],
+            progress_indices=layer.get("progress_indices"),
+            clip_start_index=layer.get("clip_start_index"),
         )
 
     if gauge_circ_area.get("visible", False):
@@ -1848,12 +2213,28 @@ def render_first_frame_image(
     if compass_area.get("visible", False):
         draw_compass_tape(draw, heading_deg, compass_area, font_medium, text_c)
     if info_area.get("visible", False):
-        draw_info_text(draw,
-                       float(interp_speeds[0]),
-                       float(interp_eles[0]),
-                       float(interp_slopes[0]),
-                       start_time + timedelta(seconds=float(interp_times[0])),
-                       info_area, font_medium, tz, text_c)
+        current_dt = start_time + timedelta(seconds=float(interp_times[0]))
+        elapsed_seconds = None
+        if time_reference is not None:
+            try:
+                elapsed_seconds = max(0.0, (current_dt - time_reference).total_seconds())
+            except Exception:
+                elapsed_seconds = None
+        draw_info_text(
+            draw,
+            float(interp_speeds[0]),
+            float(interp_eles[0]),
+            float(interp_slopes[0]),
+            current_dt,
+            info_area,
+            font_medium,
+            tz,
+            text_c,
+            elapsed_seconds=elapsed_seconds,
+            total_seconds=total_duration_seconds,
+            time_label=time_label,
+            duration_label=duration_label,
+        )
         pace_now = float(interp_pace[0])
         hr_now = float(interp_hrs[0]) if np.isfinite(interp_hrs[0]) else None
         draw_pace_hr_text(draw, pace_now, hr_now, info_area, font_medium, text_c)
@@ -1874,6 +2255,7 @@ class GPXVideoApp:
         self.gpx_start_time_raw = None
         self.gpx_end_time_raw = None
         self.start_offset_var = tk.IntVar(value=0)
+        self.show_full_track_var = tk.BooleanVar(value=False)
 
         self.element_visibility_vars = {}
         self.element_pos_entries_vars = {}
@@ -2098,6 +2480,11 @@ class GPXVideoApp:
                                        values=[str(i) for i in range(1, 13)])
         self.zoom_combo.set(str(self.map_zoom_level_var.get()))
         self.zoom_combo.pack(fill=tk.X, pady=2)
+        ttk.Checkbutton(
+            gen_params_frame,
+            text="Trace complète sur carte (temps global)",
+            variable=self.show_full_track_var,
+        ).pack(fill=tk.X, pady=(4, 2))
         # Disposition des éléments (onglet dédié)
         elements_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(elements_tab, text="Disposition")
@@ -2391,6 +2778,7 @@ class GPXVideoApp:
                 color_configs=self.color_configs,
                 map_style=self.map_style_var.get(),
                 zoom_level_ui=int(self.map_zoom_level_var.get()),
+                show_full_track=self.show_full_track_var.get(),
                 smoothing_seconds=smoothing_seconds,
             )
         except Exception as e:
@@ -2526,6 +2914,7 @@ class GPXVideoApp:
                     self.color_configs,
                     map_style=self.map_style_var.get(),
                     zoom_level_ui=int(self.map_zoom_level_var.get()),
+                    show_full_track=self.show_full_track_var.get(),
                     smoothing_seconds=smoothing_seconds,
                     progress_callback=progress_cb,
                 )


### PR DESCRIPTION
## Summary
- calculer un contexte "trace complète" pour retrouver les positions globales, les valeurs des graphiques et le repère temporel de tout le GPX
- exploiter ce contexte lors du rendu vidéo/aperçu afin de conserver le zoom choisi tout en dessinant l’ensemble de la trace et en plaçant la progression et les timings par rapport au GPX complet
- adapter le tracé des graphes pour accepter une progression décalée et n’animer que la portion correspondant au clip demandé

## Testing
- python -m compileall OverlayGPX_V1.py

------
https://chatgpt.com/codex/tasks/task_b_68cc0bbb5ba4832488111775d6ca25d9