### PR TITLE
Améliorer la compacité de l’interface et ajouter une aide intégrée

### DIFF
--- a/OverlayGPX_V1.py
+++ b/OverlayGPX_V1.py
@@ -1988,11 +1988,24 @@ class GPXVideoApp:
     def __init__(self, master):
         self.master = master
         master.title("Overlay GPX")
-        master.geometry("1800x800")
+        master.geometry("1480x720")
+        master.minsize(1280, 640)
         try:
             style = ttk.Style(); style.theme_use("clam")
         except Exception:
-            pass
+            style = ttk.Style()
+
+        style.configure("TButton", padding=(8, 4))
+        style.configure("Primary.TButton", padding=(10, 6), background="#2563eb", foreground="#ffffff")
+        style.map(
+            "Primary.TButton",
+            background=[("disabled", "#93c5fd"), ("active", "#1d4ed8")],
+            foreground=[("disabled", "#e0f2fe"), ("active", "#ffffff")],
+        )
+        style.configure("Toolbar.TFrame", background="#f8fafc")
+        style.configure("Toolbar.TLabel", background="#f8fafc")
+        style.configure("TNotebook.Tab", padding=(12, 6))
+        style.configure("TLabelframe", padding=10)
 
         self.gpx_file_path = ""
         self.gpx_start_time_raw = None
@@ -2118,88 +2131,135 @@ class GPXVideoApp:
     # ----- UI -----
     def create_widgets(self):
         main_frame = ttk.Frame(self.master)
-        main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        main_frame.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
+        main_frame.columnconfigure(0, weight=0)
+        main_frame.columnconfigure(1, weight=1)
+        main_frame.rowconfigure(1, weight=1)
 
         # Barre d’outils
-        toolbar = ttk.Frame(main_frame); toolbar.pack(fill=tk.X, pady=(0, 8))
-        ttk.Button(toolbar, text="Ouvrir GPX", command=self.select_gpx_file).pack(side=tk.LEFT, padx=2)
-        ttk.Button(toolbar, text="Prévisualiser 1ʳᵉ frame", command=self.preview_first_frame).pack(side=tk.LEFT, padx=2)
-        self.generate_btn = ttk.Button(toolbar, text="Générer Vidéo", command=self.generate_video)
-        self.generate_btn.pack(side=tk.LEFT, padx=2)
-        ttk.Separator(toolbar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=6)
-        self.gpx_toolbar_label_var = tk.StringVar(value="GPX: aucun")
-        ttk.Label(toolbar, textvariable=self.gpx_toolbar_label_var).pack(side=tk.LEFT, padx=6)
+        toolbar = ttk.Frame(main_frame, style="Toolbar.TFrame")
+        toolbar.grid(row=0, column=0, columnspan=2, sticky="ew", pady=(0, 12))
 
+        toolbar_left = ttk.Frame(toolbar, style="Toolbar.TFrame")
+        toolbar_left.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        ttk.Button(toolbar_left, text="Ouvrir GPX", command=self.select_gpx_file).pack(side=tk.LEFT, padx=4)
+        ttk.Button(toolbar_left, text="Prévisualiser 1ʳᵉ frame", command=self.preview_first_frame).pack(side=tk.LEFT, padx=4)
+        self.generate_btn = ttk.Button(toolbar_left, text="Générer Vidéo", style="Primary.TButton", command=self.generate_video)
+        self.generate_btn.pack(side=tk.LEFT, padx=4)
+        ttk.Separator(toolbar_left, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
+        self.gpx_toolbar_label_var = tk.StringVar(value="GPX: aucun")
+        ttk.Label(toolbar_left, textvariable=self.gpx_toolbar_label_var, style="Toolbar.TLabel").pack(side=tk.LEFT, padx=6)
+
+        toolbar_right = ttk.Frame(toolbar, style="Toolbar.TFrame")
+        toolbar_right.pack(side=tk.RIGHT)
+        ttk.Button(toolbar_right, text="Aide", command=self.show_help_dialog).pack(side=tk.RIGHT, padx=4)
         self.progress_time_var = tk.StringVar(value=self.progress_message_default)
-        ttk.Label(toolbar, textvariable=self.progress_time_var).pack(side=tk.RIGHT, padx=6)
+        ttk.Label(toolbar_right, textvariable=self.progress_time_var, style="Toolbar.TLabel").pack(side=tk.RIGHT, padx=6)
 
         # Colonne gauche avec onglets pour condenser l'interface
         config_panel_outer = ttk.Notebook(main_frame); self.config_panel_outer = config_panel_outer
-        config_panel_outer.pack(side=tk.LEFT, fill=tk.Y, expand=False, padx=(0, 10))
+        config_panel_outer.grid(row=1, column=0, sticky="ns", padx=(0, 12))
 
         gen_params_tab = ttk.Frame(config_panel_outer)
+        gen_params_tab.columnconfigure(0, weight=1)
+        gen_params_tab.rowconfigure(0, weight=1)
         config_panel_outer.add(gen_params_tab, text="Paramètres")
+
         gen_params_frame = ttk.LabelFrame(gen_params_tab, text="Paramètres de génération")
-        gen_params_frame.pack(fill=tk.X, pady=5, anchor="n", padx=5)
+        gen_params_frame.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
+        gen_params_frame.columnconfigure(0, weight=1)
 
-        gpx_frame = ttk.Frame(gen_params_frame); gpx_frame.pack(fill=tk.X, pady=5)
-        self.gpx_label = ttk.Label(gpx_frame, text="Fichier GPX: Aucun"); self.gpx_label.pack(side=tk.LEFT, expand=True, fill=tk.X)
+        columns_frame = ttk.Frame(gen_params_frame)
+        columns_frame.grid(row=0, column=0, sticky="nsew")
+        columns_frame.columnconfigure(0, weight=1)
+        columns_frame.columnconfigure(1, weight=1)
+        columns_frame.rowconfigure(0, weight=1)
 
-        self.gpx_start_time_label = ttk.Label(gen_params_frame, text="Début GPX: N/A"); self.gpx_start_time_label.pack(fill=tk.X, pady=2)
-        self.gpx_end_time_label = ttk.Label(gen_params_frame, text="Fin GPX: N/A"); self.gpx_end_time_label.pack(fill=tk.X, pady=2)
-        self.gpx_duration_label = ttk.Label(gen_params_frame, text="Durée GPX: N/A")
-        self.gpx_duration_label.pack(fill=tk.X, pady=2)
+        left_column = ttk.Frame(columns_frame)
+        left_column.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        left_column.columnconfigure(0, weight=1)
+        left_column.rowconfigure(1, weight=1)
 
+        right_column = ttk.Frame(columns_frame)
+        right_column.grid(row=0, column=1, sticky="nsew")
+        right_column.columnconfigure(0, weight=1)
+        right_column.rowconfigure(1, weight=1)
 
-        ttk.Label(gen_params_frame, text="Début du clip:").pack(fill=tk.X, pady=2)
-        self.start_offset_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.start_offset_var, orient=tk.HORIZONTAL)
-        self.start_offset_scale.pack(fill=tk.X, pady=2)
-        self.start_offset_label = ttk.Label(gen_params_frame, text="0:00:00")
-        self.start_offset_label.pack(fill=tk.X, pady=2)
+        gpx_frame = ttk.LabelFrame(left_column, text="Informations GPX")
+        gpx_frame.grid(row=0, column=0, sticky="nsew")
+        gpx_frame.columnconfigure(0, weight=1)
+        self.gpx_label = ttk.Label(gpx_frame, text="Fichier GPX: Aucun")
+        self.gpx_label.grid(row=0, column=0, sticky="w", pady=(0, 2))
+        self.gpx_start_time_label = ttk.Label(gpx_frame, text="Début GPX: N/A")
+        self.gpx_start_time_label.grid(row=1, column=0, sticky="w", pady=2)
+        self.gpx_end_time_label = ttk.Label(gpx_frame, text="Fin GPX: N/A")
+        self.gpx_end_time_label.grid(row=2, column=0, sticky="w", pady=2)
+        self.gpx_duration_label = ttk.Label(gpx_frame, text="Durée GPX: N/A")
+        self.gpx_duration_label.grid(row=3, column=0, sticky="w", pady=(2, 0))
+
+        clip_frame = ttk.LabelFrame(left_column, text="Fenêtre du clip")
+        clip_frame.grid(row=1, column=0, sticky="nsew", pady=(10, 0))
+        clip_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(clip_frame, text="Début du clip:").grid(row=0, column=0, sticky="w", pady=2)
+        self.start_offset_scale = ttk.Scale(clip_frame, from_=0, to=0, variable=self.start_offset_var, orient=tk.HORIZONTAL)
+        self.start_offset_scale.grid(row=0, column=1, sticky="ew", pady=2)
+        self.start_offset_label = ttk.Label(clip_frame, text="0:00:00")
+        self.start_offset_label.grid(row=0, column=2, sticky="e", padx=(6, 0))
         self.start_offset_var.trace_add("write", self.on_start_offset_change)
         self.update_start_offset_label()
 
-        ttk.Label(gen_params_frame, text="Durée du clip:").pack(fill=tk.X, pady=2)
         self.duration_var = tk.IntVar(value=DEFAULT_CLIP_DURATION_SECONDS)
-        self.duration_scale = ttk.Scale(gen_params_frame, from_=1, to=1, variable=self.duration_var, orient=tk.HORIZONTAL)
-        self.duration_scale.pack(fill=tk.X, pady=2)
-        self.duration_label = ttk.Label(gen_params_frame, text="0:00:00")
-        self.duration_label.pack(fill=tk.X, pady=2)
-        self.clip_time_label = ttk.Label(gen_params_frame, text="Clip: début N/A - fin N/A")
-        self.clip_time_label.pack(fill=tk.X, pady=2)
-        ttk.Label(gen_params_frame, text="Temps affiché avant le clip (s):").pack(fill=tk.X, pady=2)
-        self.pre_roll_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.pre_roll_var, orient=tk.HORIZONTAL)
-        self.pre_roll_scale.pack(fill=tk.X, pady=2)
-        self.pre_roll_label = ttk.Label(gen_params_frame, text="0 s")
-        self.pre_roll_label.pack(fill=tk.X, pady=2)
+        ttk.Label(clip_frame, text="Durée du clip:").grid(row=1, column=0, sticky="w", pady=2)
+        self.duration_scale = ttk.Scale(clip_frame, from_=1, to=1, variable=self.duration_var, orient=tk.HORIZONTAL)
+        self.duration_scale.grid(row=1, column=1, sticky="ew", pady=2)
+        self.duration_label = ttk.Label(clip_frame, text="0:00:00")
+        self.duration_label.grid(row=1, column=2, sticky="e", padx=(6, 0))
+
+        ttk.Label(clip_frame, text="Pré-roll (s):").grid(row=2, column=0, sticky="w", pady=2)
+        self.pre_roll_scale = ttk.Scale(clip_frame, from_=0, to=0, variable=self.pre_roll_var, orient=tk.HORIZONTAL)
+        self.pre_roll_scale.grid(row=2, column=1, sticky="ew", pady=2)
+        self.pre_roll_label = ttk.Label(clip_frame, text="0 s")
+        self.pre_roll_label.grid(row=2, column=2, sticky="e", padx=(6, 0))
         self.pre_roll_var.trace_add("write", self.on_pre_roll_change)
-        ttk.Label(gen_params_frame, text="Temps affiché après le clip (s):").pack(fill=tk.X, pady=2)
-        self.post_roll_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.post_roll_var, orient=tk.HORIZONTAL)
-        self.post_roll_scale.pack(fill=tk.X, pady=2)
-        self.post_roll_label = ttk.Label(gen_params_frame, text="0 s")
-        self.post_roll_label.pack(fill=tk.X, pady=2)
+
+        ttk.Label(clip_frame, text="Post-roll (s):").grid(row=3, column=0, sticky="w", pady=2)
+        self.post_roll_scale = ttk.Scale(clip_frame, from_=0, to=0, variable=self.post_roll_var, orient=tk.HORIZONTAL)
+        self.post_roll_scale.grid(row=3, column=1, sticky="ew", pady=2)
+        self.post_roll_label = ttk.Label(clip_frame, text="0 s")
+        self.post_roll_label.grid(row=3, column=2, sticky="e", padx=(6, 0))
         self.post_roll_var.trace_add("write", self.on_post_roll_change)
-        self.display_time_label = ttk.Label(gen_params_frame, text="Fenêtre affichée: début N/A - fin N/A")
-        self.display_time_label.pack(fill=tk.X, pady=2)
+
+        self.clip_time_label = ttk.Label(clip_frame, text="Clip: début N/A - fin N/A")
+        self.clip_time_label.grid(row=4, column=0, columnspan=3, sticky="w", pady=(6, 0))
+        self.display_time_label = ttk.Label(clip_frame, text="Fenêtre affichée: début N/A - fin N/A")
+        self.display_time_label.grid(row=5, column=0, columnspan=3, sticky="w", pady=(2, 0))
+        clip_frame.columnconfigure(0, weight=0)
+        clip_frame.columnconfigure(1, weight=1)
+        clip_frame.columnconfigure(2, weight=0)
         self.duration_var.trace_add("write", self.on_duration_slider_change)
         self.update_duration_label()
         self.update_clip_time_label()
 
+        video_frame = ttk.LabelFrame(right_column, text="Vidéo & texte")
+        video_frame.grid(row=0, column=0, sticky="nsew")
+        video_frame.columnconfigure(1, weight=1)
 
-        ttk.Label(gen_params_frame, text="FPS:").pack(fill=tk.X, pady=2)
+        ttk.Label(video_frame, text="FPS:").grid(row=0, column=0, sticky="w", pady=2)
         self.fps_entry_var = tk.StringVar(value=str(DEFAULT_FPS))
-        self.fps_entry = ttk.Entry(gen_params_frame, textvariable=self.fps_entry_var, validate="key", validatecommand=self.vcmd_int); self.fps_entry.pack(fill=tk.X, pady=2)
+        self.fps_entry = ttk.Entry(video_frame, textvariable=self.fps_entry_var, validate="key", validatecommand=self.vcmd_int)
+        self.fps_entry.grid(row=0, column=1, sticky="ew", pady=2)
 
-        ttk.Label(gen_params_frame, text="Intervalle de lissage des données (s):").pack(fill=tk.X, pady=2)
+        ttk.Label(video_frame, text="Lissage données (s):").grid(row=1, column=0, sticky="w", pady=2)
         self.graph_smoothing_entry = ttk.Entry(
-            gen_params_frame,
+            video_frame,
             textvariable=self.graph_smoothing_seconds_var,
             validate="key",
             validatecommand=self.vcmd_float,
         )
-        self.graph_smoothing_entry.pack(fill=tk.X, pady=2)
+        self.graph_smoothing_entry.grid(row=1, column=1, sticky="ew", pady=2)
 
-        ttk.Label(gen_params_frame, text="Résolution Vidéo :").pack(fill=tk.X, pady=2)
+        ttk.Label(video_frame, text="Résolution vidéo:").grid(row=2, column=0, sticky="w", pady=2)
         resolution_labels = [label for label, _ in self.resolution_presets]
         default_label = next(
             (label for label, res in self.resolution_presets if res == tuple(self.current_video_resolution)),
@@ -2207,51 +2267,54 @@ class GPXVideoApp:
         )
         self.resolution_choice_var = tk.StringVar(value=default_label)
         self.resolution_combo = ttk.Combobox(
-            gen_params_frame,
+            video_frame,
             textvariable=self.resolution_choice_var,
             values=resolution_labels,
             state="readonly",
         )
-        self.resolution_combo.pack(fill=tk.X, pady=2)
+        self.resolution_combo.grid(row=2, column=1, sticky="ew", pady=2)
         self.resolution_combo.bind("<<ComboboxSelected>>", self.on_resolution_selection_change)
 
-        ttk.Label(gen_params_frame, text="Police (TTF):").pack(fill=tk.X, pady=2)
-        font_frame = ttk.Frame(gen_params_frame)
-        font_frame.pack(fill=tk.X, pady=2)
-        ttk.Entry(font_frame, textvariable=self.font_path_var).pack(side=tk.LEFT, fill=tk.X, expand=True)
-        ttk.Button(font_frame, text="Parcourir", command=self.select_font_file).pack(side=tk.LEFT, padx=2)
+        ttk.Label(video_frame, text="Police (TTF):").grid(row=3, column=0, sticky="w", pady=(8, 2))
+        font_entry = ttk.Entry(video_frame, textvariable=self.font_path_var)
+        font_entry.grid(row=3, column=1, sticky="ew", pady=(8, 2))
+        ttk.Button(video_frame, text="Parcourir", command=self.select_font_file).grid(row=3, column=2, padx=4, pady=(8, 2))
 
-        ttk.Label(gen_params_frame, text="Taille police:").pack(fill=tk.X, pady=2)
-        ttk.Entry(gen_params_frame, textvariable=self.font_size_var, validate="key", validatecommand=self.vcmd_int).pack(fill=tk.X, pady=2)
+        ttk.Label(video_frame, text="Taille police:").grid(row=4, column=0, sticky="w", pady=2)
+        ttk.Entry(video_frame, textvariable=self.font_size_var, validate="key", validatecommand=self.vcmd_int).grid(
+            row=4, column=1, sticky="ew", pady=2
+        )
 
-        # Style de carte
-        ttk.Label(gen_params_frame, text="Style de carte:").pack(fill=tk.X, pady=2)
+        map_frame = ttk.LabelFrame(right_column, text="Carte")
+        map_frame.grid(row=1, column=0, sticky="nsew", pady=(10, 0))
+        map_frame.columnconfigure(0, weight=1)
+        ttk.Label(map_frame, text="Style de carte:").grid(row=0, column=0, sticky="w", pady=2)
         style_choices = list(MAP_TILE_SERVERS.keys())
-        self.map_style_combo = ttk.Combobox(gen_params_frame, textvariable=self.map_style_var, values=style_choices, state="readonly")
-        self.map_style_combo.pack(fill=tk.X, pady=2)
-
-        # Zoom 1..12 (combobox) — 8 = “ajusté”
-        ttk.Label(gen_params_frame, text="Zoom (1-Loin à 12-Proche) :").pack(fill=tk.X, pady=(8, 2))
-        self.zoom_combo = ttk.Combobox(gen_params_frame, textvariable=self.map_zoom_level_var, state="readonly",
+        self.map_style_combo = ttk.Combobox(map_frame, textvariable=self.map_style_var, values=style_choices, state="readonly")
+        self.map_style_combo.grid(row=1, column=0, sticky="ew", pady=2)
+        ttk.Label(map_frame, text="Zoom (1 loin → 12 proche):").grid(row=2, column=0, sticky="w", pady=(6, 2))
+        self.zoom_combo = ttk.Combobox(map_frame, textvariable=self.map_zoom_level_var, state="readonly",
                                        values=[str(i) for i in range(1, 13)])
         self.zoom_combo.set(str(self.map_zoom_level_var.get()))
-        self.zoom_combo.pack(fill=tk.X, pady=2)
+        self.zoom_combo.grid(row=3, column=0, sticky="ew", pady=2)
+
         # Disposition des éléments (onglet dédié)
         elements_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(elements_tab, text="Disposition")
         elements_outer_frame = ttk.LabelFrame(elements_tab, text="Disposition des éléments")
-        elements_outer_frame.pack(fill=tk.X, pady=10, anchor="n", padx=5)
-        scrollable_frame_elements = ttk.Frame(elements_outer_frame); scrollable_frame_elements.pack(fill=tk.X, expand=False)
+        elements_outer_frame.pack(fill=tk.BOTH, pady=10, anchor="n", padx=8)
+        scrollable_frame_elements = ttk.Frame(elements_outer_frame)
+        scrollable_frame_elements.pack(fill=tk.X, expand=False)
 
         headers = ["Élément", "Aff.", "X", "Y", "Largeur"]
         for i, _ in enumerate(headers):
-            scrollable_frame_elements.columnconfigure(i, weight=1 if i in [0, 2, 3, 4] else 0, minsize=50 if i != 0 else 80)
+            scrollable_frame_elements.columnconfigure(i, weight=1 if i in [0, 2, 3, 4] else 0, minsize=60 if i != 0 else 90)
         for col, header_text in enumerate(headers):
             ttk.Label(scrollable_frame_elements, text=header_text).grid(row=0, column=col, padx=2, pady=2, sticky="w" if col == 0 else "nsew")
 
         row_num = 1
         for element_name, defaults in DEFAULT_ELEMENT_CONFIGS.items():
-            ttk.Label(scrollable_frame_elements, text=element_name, wraplength=70).grid(row=row_num, column=0, padx=5, pady=2, sticky="w")
+            ttk.Label(scrollable_frame_elements, text=element_name, wraplength=90).grid(row=row_num, column=0, padx=5, pady=2, sticky="w")
             var = tk.BooleanVar(value=defaults["visible"])
             cb_visible = ttk.Checkbutton(scrollable_frame_elements, variable=var, command=lambda el=element_name: self.handle_element_change(el, "visible"))
             cb_visible.grid(row=row_num, column=1, padx=2, pady=2)
@@ -2277,17 +2340,18 @@ class GPXVideoApp:
                 entry_widget.bind("<FocusOut>", lambda e, el=element_name, k=key: self.handle_element_change(el, k, "entry"))
                 entry_widget.bind("<Return>",  lambda e, el=element_name, k=key: self.handle_element_change(el, k, "entry"))
 
-                slider = ttk.Scale(entry_slider_frame, variable=slider_var, orient=tk.HORIZONTAL, length=150,
+                slider = ttk.Scale(entry_slider_frame, variable=slider_var, orient=tk.HORIZONTAL, length=140,
                                    command=lambda val, el=element_name, k=key: self.handle_element_change(el, k, "slider"))
                 slider.grid(row=0, column=0, sticky="ew", padx=(0, 2))
                 self.element_sliders[element_name][key] = slider
 
             row_num += 1
+
         # Onglet Couleurs
         colors_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(colors_tab, text="Couleurs")
         colors_outer = ttk.LabelFrame(colors_tab, text="Palette de couleurs")
-        colors_outer.pack(fill=tk.X, pady=10, anchor="n", padx=5)
+        colors_outer.pack(fill=tk.BOTH, pady=10, anchor="n", padx=8)
         self.color_preview_frames = {}
         row = 0
         for key, label_text in self.color_labels.items():
@@ -2296,26 +2360,51 @@ class GPXVideoApp:
                               background=self.color_configs.get(key, "#FFFFFF"))
             swatch.grid(row=row, column=1, padx=6, pady=4, sticky="w")
             self.color_preview_frames[key] = swatch
+
             def make_pick(k=key, frame=swatch):
                 return lambda: self.pick_color(k, frame)
+
             ttk.Button(colors_outer, text="Modifier…", command=make_pick()).grid(row=row, column=2, padx=4, pady=4)
             row += 1
         btns = ttk.Frame(colors_outer)
-        btns.grid(row=row, column=0, columnspan=3, pady=(0, 4))
+        btns.grid(row=row, column=0, columnspan=3, pady=(6, 4))
+
         def reset_colors():
             for k, rgb in self.default_color_map.items():
                 self.color_configs[k] = rgb_to_hex(rgb)
                 if k in self.color_preview_frames:
                     self.color_preview_frames[k].config(background=self.color_configs[k])
             self.show_preview(force_update=True)
-        ttk.Button(btns, text="Réinitialiser", command=reset_colors).pack(side=tk.LEFT)
+
+        ttk.Button(btns, text="Réinitialiser", command=reset_colors).pack(side=tk.LEFT, padx=4)
 
         # Panneau d’aperçu
         preview_panel_frame = ttk.LabelFrame(main_frame, text="Aperçu de la disposition")
-        preview_panel_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(10, 0))
+        preview_panel_frame.grid(row=1, column=1, sticky="nsew")
+        preview_panel_frame.columnconfigure(0, weight=1)
+        preview_panel_frame.rowconfigure(0, weight=1)
         self.preview_label = ttk.Label(preview_panel_frame, text="L'aperçu apparaîtra ici.", anchor="center", relief="groove")
-        self.preview_label.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.preview_label.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
         self.preview_label.bind("<Configure>", self.on_preview_resize)
+
+    def show_help_dialog(self):
+        help_text = (
+            "Barre d'outils\n"
+            "• Ouvrir GPX : sélectionne un fichier GPX et met à jour les informations du parcours.\n"
+            "• Prévisualiser 1ʳᵉ frame : génère une image rapide pour valider la disposition.\n"
+            "• Générer Vidéo : lance le rendu complet de la vidéo avec les réglages courants.\n"
+            "\nOnglet Paramètres\n"
+            "• Informations GPX : affiche le fichier chargé ainsi que sa fenêtre temporelle.\n"
+            "• Fenêtre du clip : réglez le début, la durée ainsi que les temps d'avant/après clip.\n"
+            "• Vidéo & texte : ajustez la fréquence d'images, le lissage, la résolution et la police.\n"
+            "• Carte : choisissez le style de fond et le niveau de zoom utilisé pour l'aperçu.\n"
+            "\nOnglet Disposition\n"
+            "• Activez ou non chaque élément et ajustez sa position à l'aide des curseurs.\n"
+            "\nOnglet Couleurs\n"
+            "• Personnalisez les couleurs du fond, des graphes et des textes ou revenez aux valeurs par défaut.\n"
+            "\nAstuce : validez régulièrement avec l'aperçu pour vérifier l'équilibre de votre composition."
+        )
+        messagebox.showinfo("Aide", help_text)
 
     def pick_color(self, key, preview_frame=None):
         initial = self.color_configs.get(key, "#FFFFFF")


### PR DESCRIPTION
## Summary
- réorganise les paramètres dans une disposition en colonnes pour réduire la hauteur nécessaire
- applique un style ttk modernisé, redimensionne la fenêtre et ajoute un bouton d’aide
- introduit une boîte de dialogue d’aide qui décrit les onglets et principales actions

## Testing
- python -m compileall OverlayGPX_V1.py

------
https://chatgpt.com/codex/tasks/task_b_68d678e578e083248d3e61db9213b6de