### PR TITLE
Reorganize Tkinter UI for compact layout and add help dialog

### DIFF
--- a/OverlayGPX_V1.py
+++ b/OverlayGPX_V1.py
@@ -1988,11 +1988,15 @@ class GPXVideoApp:
     def __init__(self, master):
         self.master = master
         master.title("Overlay GPX")
-        master.geometry("1800x800")
+        master.geometry("1400x760")
+        master.minsize(1200, 700)
         try:
-            style = ttk.Style(); style.theme_use("clam")
+            style = ttk.Style()
+            style.theme_use("clam")
         except Exception:
-            pass
+            style = ttk.Style()
+        self.style = style
+        self._configure_style()
 
         self.gpx_file_path = ""
         self.gpx_start_time_raw = None
@@ -2082,6 +2086,30 @@ class GPXVideoApp:
         for key, frame in self.color_preview_frames.items():
             frame.config(background=self.color_configs.get(key, "#FFFFFF"))
 
+    def _configure_style(self):
+        style = getattr(self, "style", ttk.Style())
+        try:
+            self.master.configure(background="#eef2f9")
+        except Exception:
+            pass
+        style.configure("Toolbar.TFrame", background="#eef2f9", padding=6)
+        style.configure("Toolbar.TLabel", background="#eef2f9")
+        style.configure("Toolbar.TButton", padding=(10, 6), background="#e3e9f7")
+        style.map(
+            "Toolbar.TButton",
+            background=[("active", "#d0d8f0")],
+        )
+        style.configure("Accent.TButton", padding=(10, 6), background="#2d6cdf", foreground="#ffffff")
+        style.map(
+            "Accent.TButton",
+            background=[("active", "#2448a6")],
+            foreground=[("active", "#ffffff")],
+        )
+        style.configure("Card.TLabelframe", padding=(10, 6))
+        style.configure("Card.TLabelframe.Label", font=("Helvetica", 10, "bold"))
+        style.configure("TNotebook", padding=4)
+        style.configure("TNotebook.Tab", padding=(12, 6))
+
     def populate_initial_element_ratios(self):
         for element_name, defaults in DEFAULT_ELEMENT_CONFIGS.items():
             if defaults["width"] > 0:
@@ -2117,89 +2145,117 @@ class GPXVideoApp:
 
     # ----- UI -----
     def create_widgets(self):
-        main_frame = ttk.Frame(self.master)
-        main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        self.master.columnconfigure(0, weight=1)
+        self.master.rowconfigure(0, weight=1)
+
+        main_frame = ttk.Frame(self.master, padding=10)
+        main_frame.grid(row=0, column=0, sticky="nsew")
+        main_frame.columnconfigure(0, weight=0)
+        main_frame.columnconfigure(1, weight=1)
+        main_frame.rowconfigure(1, weight=1)
 
         # Barre d’outils
-        toolbar = ttk.Frame(main_frame); toolbar.pack(fill=tk.X, pady=(0, 8))
-        ttk.Button(toolbar, text="Ouvrir GPX", command=self.select_gpx_file).pack(side=tk.LEFT, padx=2)
-        ttk.Button(toolbar, text="Prévisualiser 1ʳᵉ frame", command=self.preview_first_frame).pack(side=tk.LEFT, padx=2)
-        self.generate_btn = ttk.Button(toolbar, text="Générer Vidéo", command=self.generate_video)
-        self.generate_btn.pack(side=tk.LEFT, padx=2)
+        toolbar = ttk.Frame(main_frame, style="Toolbar.TFrame")
+        toolbar.grid(row=0, column=0, columnspan=2, sticky="ew", pady=(0, 8))
+        ttk.Button(toolbar, text="Ouvrir GPX", command=self.select_gpx_file, style="Toolbar.TButton").pack(side=tk.LEFT, padx=2)
+        ttk.Button(toolbar, text="Prévisualiser 1ʳᵉ frame", command=self.preview_first_frame, style="Toolbar.TButton").pack(side=tk.LEFT, padx=2)
+        self.generate_btn = ttk.Button(toolbar, text="Générer Vidéo", command=self.generate_video, style="Accent.TButton")
+        self.generate_btn.pack(side=tk.LEFT, padx=6)
         ttk.Separator(toolbar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=6)
         self.gpx_toolbar_label_var = tk.StringVar(value="GPX: aucun")
-        ttk.Label(toolbar, textvariable=self.gpx_toolbar_label_var).pack(side=tk.LEFT, padx=6)
+        ttk.Label(toolbar, textvariable=self.gpx_toolbar_label_var, style="Toolbar.TLabel").pack(side=tk.LEFT, padx=6)
 
         self.progress_time_var = tk.StringVar(value=self.progress_message_default)
-        ttk.Label(toolbar, textvariable=self.progress_time_var).pack(side=tk.RIGHT, padx=6)
+        ttk.Button(toolbar, text="Aide", command=self.show_help, style="Toolbar.TButton").pack(side=tk.RIGHT, padx=2)
+        ttk.Label(toolbar, textvariable=self.progress_time_var, style="Toolbar.TLabel").pack(side=tk.RIGHT, padx=6)
 
         # Colonne gauche avec onglets pour condenser l'interface
         config_panel_outer = ttk.Notebook(main_frame); self.config_panel_outer = config_panel_outer
-        config_panel_outer.pack(side=tk.LEFT, fill=tk.Y, expand=False, padx=(0, 10))
+        config_panel_outer.grid(row=1, column=0, sticky="ns", padx=(0, 12))
 
         gen_params_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(gen_params_tab, text="Paramètres")
-        gen_params_frame = ttk.LabelFrame(gen_params_tab, text="Paramètres de génération")
-        gen_params_frame.pack(fill=tk.X, pady=5, anchor="n", padx=5)
+        gen_params_tab.columnconfigure(0, weight=1)
 
-        gpx_frame = ttk.Frame(gen_params_frame); gpx_frame.pack(fill=tk.X, pady=5)
-        self.gpx_label = ttk.Label(gpx_frame, text="Fichier GPX: Aucun"); self.gpx_label.pack(side=tk.LEFT, expand=True, fill=tk.X)
+        gpx_info_frame = ttk.LabelFrame(gen_params_tab, text="Fichier GPX", style="Card.TLabelframe")
+        gpx_info_frame.pack(fill=tk.X, padx=6, pady=(6, 4))
+        gpx_info_frame.columnconfigure(0, weight=1)
 
-        self.gpx_start_time_label = ttk.Label(gen_params_frame, text="Début GPX: N/A"); self.gpx_start_time_label.pack(fill=tk.X, pady=2)
-        self.gpx_end_time_label = ttk.Label(gen_params_frame, text="Fin GPX: N/A"); self.gpx_end_time_label.pack(fill=tk.X, pady=2)
-        self.gpx_duration_label = ttk.Label(gen_params_frame, text="Durée GPX: N/A")
-        self.gpx_duration_label.pack(fill=tk.X, pady=2)
+        self.gpx_label = ttk.Label(gpx_info_frame, text="Fichier GPX: Aucun", wraplength=260)
+        self.gpx_label.grid(row=0, column=0, sticky="w", pady=2)
+        self.gpx_start_time_label = ttk.Label(gpx_info_frame, text="Début GPX: N/A")
+        self.gpx_start_time_label.grid(row=1, column=0, sticky="w", pady=2)
+        self.gpx_end_time_label = ttk.Label(gpx_info_frame, text="Fin GPX: N/A")
+        self.gpx_end_time_label.grid(row=2, column=0, sticky="w", pady=2)
+        self.gpx_duration_label = ttk.Label(gpx_info_frame, text="Durée GPX: N/A")
+        self.gpx_duration_label.grid(row=3, column=0, sticky="w", pady=(2, 0))
 
+        param_tabs = ttk.Notebook(gen_params_tab)
+        param_tabs.pack(fill=tk.BOTH, expand=True, padx=6, pady=(0, 6))
 
-        ttk.Label(gen_params_frame, text="Début du clip:").pack(fill=tk.X, pady=2)
-        self.start_offset_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.start_offset_var, orient=tk.HORIZONTAL)
-        self.start_offset_scale.pack(fill=tk.X, pady=2)
-        self.start_offset_label = ttk.Label(gen_params_frame, text="0:00:00")
-        self.start_offset_label.pack(fill=tk.X, pady=2)
+        # Onglet Fenêtre temporelle
+        window_tab = ttk.Frame(param_tabs)
+        window_tab.columnconfigure(0, weight=1)
+        window_tab.columnconfigure(1, weight=0)
+        param_tabs.add(window_tab, text="Fenêtre temporelle")
+
+        ttk.Label(window_tab, text="Début du clip:").grid(row=0, column=0, sticky="w", padx=4, pady=(6, 0))
+        self.start_offset_label = ttk.Label(window_tab, text="0:00:00")
+        self.start_offset_label.grid(row=0, column=1, sticky="e", padx=4, pady=(6, 0))
+        self.start_offset_scale = ttk.Scale(window_tab, from_=0, to=0, variable=self.start_offset_var, orient=tk.HORIZONTAL)
+        self.start_offset_scale.grid(row=1, column=0, columnspan=2, sticky="ew", padx=4, pady=(0, 6))
         self.start_offset_var.trace_add("write", self.on_start_offset_change)
         self.update_start_offset_label()
 
-        ttk.Label(gen_params_frame, text="Durée du clip:").pack(fill=tk.X, pady=2)
+        ttk.Label(window_tab, text="Durée du clip:").grid(row=2, column=0, sticky="w", padx=4)
         self.duration_var = tk.IntVar(value=DEFAULT_CLIP_DURATION_SECONDS)
-        self.duration_scale = ttk.Scale(gen_params_frame, from_=1, to=1, variable=self.duration_var, orient=tk.HORIZONTAL)
-        self.duration_scale.pack(fill=tk.X, pady=2)
-        self.duration_label = ttk.Label(gen_params_frame, text="0:00:00")
-        self.duration_label.pack(fill=tk.X, pady=2)
-        self.clip_time_label = ttk.Label(gen_params_frame, text="Clip: début N/A - fin N/A")
-        self.clip_time_label.pack(fill=tk.X, pady=2)
-        ttk.Label(gen_params_frame, text="Temps affiché avant le clip (s):").pack(fill=tk.X, pady=2)
-        self.pre_roll_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.pre_roll_var, orient=tk.HORIZONTAL)
-        self.pre_roll_scale.pack(fill=tk.X, pady=2)
-        self.pre_roll_label = ttk.Label(gen_params_frame, text="0 s")
-        self.pre_roll_label.pack(fill=tk.X, pady=2)
+        self.duration_label = ttk.Label(window_tab, text="0:00:00")
+        self.duration_label.grid(row=2, column=1, sticky="e", padx=4)
+        self.duration_scale = ttk.Scale(window_tab, from_=1, to=1, variable=self.duration_var, orient=tk.HORIZONTAL)
+        self.duration_scale.grid(row=3, column=0, columnspan=2, sticky="ew", padx=4, pady=(0, 6))
+
+        ttk.Label(window_tab, text="Temps avant le clip (s):").grid(row=4, column=0, sticky="w", padx=4)
+        self.pre_roll_label = ttk.Label(window_tab, text="0 s")
+        self.pre_roll_label.grid(row=4, column=1, sticky="e", padx=4)
+        self.pre_roll_scale = ttk.Scale(window_tab, from_=0, to=0, variable=self.pre_roll_var, orient=tk.HORIZONTAL)
+        self.pre_roll_scale.grid(row=5, column=0, columnspan=2, sticky="ew", padx=4, pady=(0, 6))
         self.pre_roll_var.trace_add("write", self.on_pre_roll_change)
-        ttk.Label(gen_params_frame, text="Temps affiché après le clip (s):").pack(fill=tk.X, pady=2)
-        self.post_roll_scale = ttk.Scale(gen_params_frame, from_=0, to=0, variable=self.post_roll_var, orient=tk.HORIZONTAL)
-        self.post_roll_scale.pack(fill=tk.X, pady=2)
-        self.post_roll_label = ttk.Label(gen_params_frame, text="0 s")
-        self.post_roll_label.pack(fill=tk.X, pady=2)
+
+        ttk.Label(window_tab, text="Temps après le clip (s):").grid(row=6, column=0, sticky="w", padx=4)
+        self.post_roll_label = ttk.Label(window_tab, text="0 s")
+        self.post_roll_label.grid(row=6, column=1, sticky="e", padx=4)
+        self.post_roll_scale = ttk.Scale(window_tab, from_=0, to=0, variable=self.post_roll_var, orient=tk.HORIZONTAL)
+        self.post_roll_scale.grid(row=7, column=0, columnspan=2, sticky="ew", padx=4, pady=(0, 6))
         self.post_roll_var.trace_add("write", self.on_post_roll_change)
-        self.display_time_label = ttk.Label(gen_params_frame, text="Fenêtre affichée: début N/A - fin N/A")
-        self.display_time_label.pack(fill=tk.X, pady=2)
+
+        self.clip_time_label = ttk.Label(window_tab, text="Clip: début N/A - fin N/A", wraplength=260)
+        self.clip_time_label.grid(row=8, column=0, columnspan=2, sticky="w", padx=4, pady=(4, 0))
+        self.display_time_label = ttk.Label(window_tab, text="Fenêtre affichée: début N/A - fin N/A", wraplength=260)
+        self.display_time_label.grid(row=9, column=0, columnspan=2, sticky="w", padx=4, pady=(2, 8))
         self.duration_var.trace_add("write", self.on_duration_slider_change)
         self.update_duration_label()
         self.update_clip_time_label()
 
+        # Onglet Vidéo & données
+        video_tab = ttk.Frame(param_tabs)
+        video_tab.columnconfigure(1, weight=1)
+        param_tabs.add(video_tab, text="Vidéo & données")
 
-        ttk.Label(gen_params_frame, text="FPS:").pack(fill=tk.X, pady=2)
+        ttk.Label(video_tab, text="FPS:").grid(row=0, column=0, sticky="w", padx=4, pady=(8, 2))
         self.fps_entry_var = tk.StringVar(value=str(DEFAULT_FPS))
-        self.fps_entry = ttk.Entry(gen_params_frame, textvariable=self.fps_entry_var, validate="key", validatecommand=self.vcmd_int); self.fps_entry.pack(fill=tk.X, pady=2)
+        self.fps_entry = ttk.Entry(video_tab, textvariable=self.fps_entry_var, validate="key", validatecommand=self.vcmd_int)
+        self.fps_entry.grid(row=0, column=1, sticky="ew", padx=4, pady=(8, 2))
 
-        ttk.Label(gen_params_frame, text="Intervalle de lissage des données (s):").pack(fill=tk.X, pady=2)
+        ttk.Label(video_tab, text="Intervalle de lissage (s):").grid(row=1, column=0, sticky="w", padx=4, pady=2)
         self.graph_smoothing_entry = ttk.Entry(
-            gen_params_frame,
+            video_tab,
             textvariable=self.graph_smoothing_seconds_var,
             validate="key",
             validatecommand=self.vcmd_float,
         )
-        self.graph_smoothing_entry.pack(fill=tk.X, pady=2)
+        self.graph_smoothing_entry.grid(row=1, column=1, sticky="ew", padx=4, pady=2)
 
-        ttk.Label(gen_params_frame, text="Résolution Vidéo :").pack(fill=tk.X, pady=2)
+        ttk.Label(video_tab, text="Résolution vidéo:").grid(row=2, column=0, sticky="w", padx=4, pady=2)
         resolution_labels = [label for label, _ in self.resolution_presets]
         default_label = next(
             (label for label, res in self.resolution_presets if res == tuple(self.current_video_resolution)),
@@ -2207,41 +2263,55 @@ class GPXVideoApp:
         )
         self.resolution_choice_var = tk.StringVar(value=default_label)
         self.resolution_combo = ttk.Combobox(
-            gen_params_frame,
+            video_tab,
             textvariable=self.resolution_choice_var,
             values=resolution_labels,
             state="readonly",
         )
-        self.resolution_combo.pack(fill=tk.X, pady=2)
+        self.resolution_combo.grid(row=2, column=1, sticky="ew", padx=4, pady=2)
         self.resolution_combo.bind("<<ComboboxSelected>>", self.on_resolution_selection_change)
 
-        ttk.Label(gen_params_frame, text="Police (TTF):").pack(fill=tk.X, pady=2)
-        font_frame = ttk.Frame(gen_params_frame)
-        font_frame.pack(fill=tk.X, pady=2)
-        ttk.Entry(font_frame, textvariable=self.font_path_var).pack(side=tk.LEFT, fill=tk.X, expand=True)
-        ttk.Button(font_frame, text="Parcourir", command=self.select_font_file).pack(side=tk.LEFT, padx=2)
+        # Onglet Apparence
+        appearance_tab = ttk.Frame(param_tabs)
+        appearance_tab.columnconfigure(0, weight=1)
+        param_tabs.add(appearance_tab, text="Apparence")
 
-        ttk.Label(gen_params_frame, text="Taille police:").pack(fill=tk.X, pady=2)
-        ttk.Entry(gen_params_frame, textvariable=self.font_size_var, validate="key", validatecommand=self.vcmd_int).pack(fill=tk.X, pady=2)
+        ttk.Label(appearance_tab, text="Police (TTF):").grid(row=0, column=0, sticky="w", padx=4, pady=(8, 2))
+        font_frame = ttk.Frame(appearance_tab)
+        font_frame.grid(row=1, column=0, sticky="ew", padx=4)
+        font_frame.columnconfigure(0, weight=1)
+        ttk.Entry(font_frame, textvariable=self.font_path_var).grid(row=0, column=0, sticky="ew")
+        ttk.Button(font_frame, text="Parcourir", command=self.select_font_file, style="Toolbar.TButton").grid(row=0, column=1, padx=(6, 0))
 
-        # Style de carte
-        ttk.Label(gen_params_frame, text="Style de carte:").pack(fill=tk.X, pady=2)
+        ttk.Label(appearance_tab, text="Taille de police:").grid(row=2, column=0, sticky="w", padx=4, pady=(10, 2))
+        ttk.Entry(appearance_tab, textvariable=self.font_size_var, validate="key", validatecommand=self.vcmd_int).grid(row=3, column=0, sticky="ew", padx=4)
+
+        # Onglet Carte
+        map_tab = ttk.Frame(param_tabs)
+        map_tab.columnconfigure(0, weight=1)
+        param_tabs.add(map_tab, text="Carte")
+
+        ttk.Label(map_tab, text="Style de carte:").grid(row=0, column=0, sticky="w", padx=4, pady=(8, 2))
         style_choices = list(MAP_TILE_SERVERS.keys())
-        self.map_style_combo = ttk.Combobox(gen_params_frame, textvariable=self.map_style_var, values=style_choices, state="readonly")
-        self.map_style_combo.pack(fill=tk.X, pady=2)
+        self.map_style_combo = ttk.Combobox(map_tab, textvariable=self.map_style_var, values=style_choices, state="readonly")
+        self.map_style_combo.grid(row=1, column=0, sticky="ew", padx=4, pady=2)
 
-        # Zoom 1..12 (combobox) — 8 = “ajusté”
-        ttk.Label(gen_params_frame, text="Zoom (1-Loin à 12-Proche) :").pack(fill=tk.X, pady=(8, 2))
-        self.zoom_combo = ttk.Combobox(gen_params_frame, textvariable=self.map_zoom_level_var, state="readonly",
-                                       values=[str(i) for i in range(1, 13)])
+        ttk.Label(map_tab, text="Zoom (1 loin – 12 proche):").grid(row=2, column=0, sticky="w", padx=4, pady=(8, 2))
+        self.zoom_combo = ttk.Combobox(
+            map_tab,
+            textvariable=self.map_zoom_level_var,
+            state="readonly",
+            values=[str(i) for i in range(1, 13)],
+        )
         self.zoom_combo.set(str(self.map_zoom_level_var.get()))
-        self.zoom_combo.pack(fill=tk.X, pady=2)
+        self.zoom_combo.grid(row=3, column=0, sticky="ew", padx=4, pady=(0, 8))
+
         # Disposition des éléments (onglet dédié)
         elements_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(elements_tab, text="Disposition")
-        elements_outer_frame = ttk.LabelFrame(elements_tab, text="Disposition des éléments")
-        elements_outer_frame.pack(fill=tk.X, pady=10, anchor="n", padx=5)
-        scrollable_frame_elements = ttk.Frame(elements_outer_frame); scrollable_frame_elements.pack(fill=tk.X, expand=False)
+        elements_outer_frame = ttk.LabelFrame(elements_tab, text="Disposition des éléments", style="Card.TLabelframe")
+        elements_outer_frame.pack(fill=tk.BOTH, expand=True, pady=10, anchor="n", padx=5)
+        scrollable_frame_elements = ttk.Frame(elements_outer_frame); scrollable_frame_elements.pack(fill=tk.BOTH, expand=True)
 
         headers = ["Élément", "Aff.", "X", "Y", "Largeur"]
         for i, _ in enumerate(headers):
@@ -2286,8 +2356,8 @@ class GPXVideoApp:
         # Onglet Couleurs
         colors_tab = ttk.Frame(config_panel_outer)
         config_panel_outer.add(colors_tab, text="Couleurs")
-        colors_outer = ttk.LabelFrame(colors_tab, text="Palette de couleurs")
-        colors_outer.pack(fill=tk.X, pady=10, anchor="n", padx=5)
+        colors_outer = ttk.LabelFrame(colors_tab, text="Palette de couleurs", style="Card.TLabelframe")
+        colors_outer.pack(fill=tk.BOTH, expand=True, pady=10, anchor="n", padx=5)
         self.color_preview_frames = {}
         row = 0
         for key, label_text in self.color_labels.items():
@@ -2308,14 +2378,30 @@ class GPXVideoApp:
                 if k in self.color_preview_frames:
                     self.color_preview_frames[k].config(background=self.color_configs[k])
             self.show_preview(force_update=True)
-        ttk.Button(btns, text="Réinitialiser", command=reset_colors).pack(side=tk.LEFT)
+        ttk.Button(btns, text="Réinitialiser", command=reset_colors, style="Toolbar.TButton").pack(side=tk.LEFT)
 
         # Panneau d’aperçu
-        preview_panel_frame = ttk.LabelFrame(main_frame, text="Aperçu de la disposition")
-        preview_panel_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(10, 0))
+        preview_panel_frame = ttk.LabelFrame(main_frame, text="Aperçu de la disposition", style="Card.TLabelframe")
+        preview_panel_frame.grid(row=1, column=1, sticky="nsew")
         self.preview_label = ttk.Label(preview_panel_frame, text="L'aperçu apparaîtra ici.", anchor="center", relief="groove")
         self.preview_label.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
         self.preview_label.bind("<Configure>", self.on_preview_resize)
+
+    def show_help(self):
+        help_text = (
+            "• Ouvrir GPX : sélectionne le fichier d'activité et initialise les paramètres.\n"
+            "• Prévisualiser 1ʳᵉ frame : génère un aperçu statique avec les réglages courants.\n"
+            "• Générer Vidéo : lance le rendu complet vers un fichier MP4.\n\n"
+            "Onglet Paramètres :\n"
+            "  – Fenêtre temporelle : choisissez la portion de trace via les curseurs de début, durée et marges.\n"
+            "  – Vidéo & données : définissez FPS, lissage des données et résolution de sortie.\n"
+            "  – Apparence : sélectionnez la police et sa taille pour les textes.\n"
+            "  – Carte : changez le fond cartographique et le niveau de zoom.\n\n"
+            "Onglet Disposition : activez/positionnez chaque élément de l'overlay (coordonnées et largeur).\n"
+            "Onglet Couleurs : personnalisez rapidement la palette graphique.\n\n"
+            "Le panneau d'aperçu reflète instantanément vos réglages pour faciliter la mise en page."
+        )
+        messagebox.showinfo("Aide", help_text)
 
     def pick_color(self, key, preview_frame=None):
         initial = self.color_configs.get(key, "#FFFFFF")


### PR DESCRIPTION
## Summary
- condense the parameter interface with grid-based notebooks so all controls fit in a smaller window
- refresh ttk styling and layout spacing for a more modern presentation while keeping the preview visible
- add a contextual help dialog accessible from the toolbar to explain each section

## Testing
- python -m py_compile OverlayGPX_V1.py

------
https://chatgpt.com/codex/tasks/task_b_68d678e578e083248d3e61db9213b6de