### PR TITLE
Fix WebMercator centering and add alignment debug tools

### DIFF
--- a/OverlayGPX_V1.py
+++ b/OverlayGPX_V1.py
@@ -63,6 +63,11 @@ CURRENT_POINT_COLOR = (255, 0, 0)
 TEXT_COLOR = (255, 255, 255)
 GAUGE_BG_COLOR = (30, 30, 30)
 
+PATCH_FACTOR = 2.4
+MAX_LARGE_DIM = 4096
+VERTICAL_BIAS = float(os.getenv("VERTICAL_BIAS", "0.65"))
+DEBUG_ALIGNMENT = bool(int(os.getenv("DEBUG_ALIGNMENT", "0")))
+
 FONT_SIZE_LARGE = 40
 FONT_SIZE_MEDIUM = 20
 GRAPH_FONT_SCALE = 0.7
@@ -494,6 +499,13 @@ def lonlat_to_pixel(lon: float, lat: float, zoom: int):
     siny = math.sin(math.radians(lat))
     y = (0.5 - math.log((1 + siny) / (1 - siny)) / (4 * math.pi)) * n
     return x, y
+
+
+def pixel_to_lonlat(x, y, zoom):
+    n = 256 * (2 ** zoom)
+    lon = x / n * 360.0 - 180.0
+    lat = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
+    return lon, lat
 
 
 def lonlat_to_pixel_np(lons, lats, zoom: int):
@@ -1225,11 +1237,6 @@ def generate_gpx_video(
     pre_roll_seconds: int = 0,
     post_roll_seconds: int = 0,
 ) -> bool:
-    # --- Config interne ---
-    PATCH_FACTOR = 2.4
-    MAX_LARGE_DIM = 4096
-    VERTICAL_BIAS = 0.65
-
     # Polices & couleurs
     graph_font_size = compute_graph_font_size(FONT_SIZE_MEDIUM)
     try:
@@ -1375,8 +1382,6 @@ def generate_gpx_video(
     # BBox brute & centre
     lat_min_raw = float(np.min(lats)); lat_max_raw = float(np.max(lats))
     lon_min_raw = float(np.min(lons)); lon_max_raw = float(np.max(lons))
-    lat_c = (lat_min_raw + lat_max_raw) * 0.5
-    lon_c = (lon_min_raw + lon_max_raw) * 0.5
 
     # Profils (altitude & vitesse)
     elev_min = float(np.min(interp_eles))
@@ -1446,22 +1451,22 @@ def generate_gpx_video(
         # Positions "monde" au zoom choisi
         xs_world, ys_world = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
 
-        # Etendue, marge et image "large"
-        x_min = float(np.min(xs_world)); x_max = float(np.max(xs_world))
-        y_min = float(np.min(ys_world)); y_max = float(np.max(ys_world))
-        track_w = x_max - x_min; track_h = y_max - y_min
+        x_min, x_max = float(np.min(xs_world)), float(np.max(xs_world))
+        y_min, y_max = float(np.min(ys_world)), float(np.max(ys_world))
+        cx_px = (x_min + x_max) * 0.5
+        cy_px = (y_min + y_max) * 0.5
+
+        lon_c, lat_c = pixel_to_lonlat(cx_px, cy_px, zoom)
 
         patch_w = int(math.ceil(mw * PATCH_FACTOR))
         patch_h = int(math.ceil(mh * PATCH_FACTOR))
         margin_x = patch_w // 2 + 64
         margin_y = patch_h // 2 + 64
-        width_large  = int(min(MAX_LARGE_DIM, max(est_w, track_w + 2 * margin_x)))
-        height_large = int(min(MAX_LARGE_DIM, max(est_h, track_h + 2 * margin_y)))
+        width_large = int(min(MAX_LARGE_DIM, max(mw, (x_max - x_min) + 2 * margin_x)))
+        height_large = int(min(MAX_LARGE_DIM, max(mh, (y_max - y_min) + 2 * margin_y)))
 
-        # Coin haut-gauche de l'image "large" basé sur le centre du fond de carte
-        cx, cy = lonlat_to_pixel(lon_c, lat_c, zoom)
-        x0_world = cx - width_large / 2.0
-        y0_world = cy - height_large / 2.0
+        x0_world = cx_px - width_large / 2.0
+        y0_world = cy_px - height_large / 2.0
 
         # Fond "large"
         try:
@@ -1473,9 +1478,9 @@ def generate_gpx_video(
             base_map_img_large = Image.new("RGB", (width_large, height_large), bg_c)
 
         # Trace dans le repère "large"
-        x_full = xs_world - x0_world
-        y_full = ys_world - y0_world
-        global_xy = np.column_stack((np.rint(x_full).astype(int), np.rint(y_full).astype(int)))
+        xs_local = xs_world - x0_world
+        ys_local = ys_world - y0_world
+        global_xy = np.column_stack((xs_local, ys_local))
         local_xy_buffer = np.empty_like(global_xy)
 
         # Tête lissée (pour rotation)
@@ -1485,10 +1490,10 @@ def generate_gpx_video(
             dx = np.zeros(total_samples, dtype=float)
             dy = np.zeros(total_samples, dtype=float)
             if total_samples > 1:
-                dx[:-1] = np.diff(x_full)
-                dy[:-1] = np.diff(y_full)
-                dx[-1] = x_full[-1] - x_full[-2]
-                dy[-1] = y_full[-1] - y_full[-2]
+                dx[:-1] = np.diff(xs_local)
+                dy[:-1] = np.diff(ys_local)
+                dx[-1] = xs_local[-1] - xs_local[-2]
+                dy[-1] = ys_local[-1] - ys_local[-2]
             headings = np.zeros(total_samples, dtype=float)
             non_zero = (np.abs(dx) > 1e-9) | (np.abs(dy) > 1e-9)
             headings[non_zero] = np.arctan2(dx[non_zero], -dy[non_zero])
@@ -1520,7 +1525,7 @@ def generate_gpx_video(
             draw = ImageDraw.Draw(frame_img)
 
             # Patch centré sur le point courant
-            xc = float(x_full[global_idx]); yc = float(y_full[global_idx])
+            xc = float(xs_local[global_idx]); yc = float(ys_local[global_idx])
             patch_left = int(round(xc - patch_w / 2.0))
             patch_top  = int(round(yc - patch_h / 2.0))
             patch_img = Image.new("RGB", (patch_w, patch_h), bg_c)
@@ -1539,12 +1544,19 @@ def generate_gpx_video(
             pdraw = ImageDraw.Draw(patch_img)
             np.subtract(global_xy[:, 0], patch_left, out=local_xy_buffer[:, 0])
             np.subtract(global_xy[:, 1], patch_top, out=local_xy_buffer[:, 1])
-            local_xy_list = [(int(pt[0]), int(pt[1])) for pt in local_xy_buffer]
+            local_xy_list = [
+                (int(round(pt[0])), int(round(pt[1]))) for pt in local_xy_buffer
+            ]
             pdraw.line(local_xy_list, fill=map_path_c, width=3)
             pdraw.line(local_xy_list[: global_idx + 1], fill=map_current_path_c, width=4)
             cxp, cyp = local_xy_buffer[global_idx]
             r = 6
-            pdraw.ellipse((int(cxp - r), int(cyp - r), int(cxp + r), int(cyp + r)), fill=map_current_point_c)
+            cxp_i = int(round(cxp))
+            cyp_i = int(round(cyp))
+            pdraw.ellipse(
+                (cxp_i - r, cyp_i - r, cxp_i + r, cyp_i + r),
+                fill=map_current_point_c,
+            )
 
             # Rotation patch (cadre fixe)
             speed_kmh = float(interp_speeds[global_idx])
@@ -1566,7 +1578,18 @@ def generate_gpx_video(
             view = patch_img.crop((view_left, view_top, view_left + mw, view_top + mh))
 
             # Collage final
-            frame_img.paste(view, (int(map_area.get("x", 0)), int(map_area.get("y", 0))))
+            map_x = int(map_area.get("x", 0))
+            map_y = int(map_area.get("y", 0))
+            frame_img.paste(view, (map_x, map_y))
+            if DEBUG_ALIGNMENT:
+                cx_screen = map_x + mw // 2
+                cy_screen = map_y + int(VERTICAL_BIAS * mh)
+                r = 6
+                draw.ellipse(
+                    (cx_screen - r, cy_screen - r, cx_screen + r, cy_screen + r),
+                    outline=(255, 0, 255),
+                    width=2,
+                )
             draw_north_arrow(frame_img, map_area, heading_deg, text_c)
 
             # Profils & infos
@@ -1681,11 +1704,6 @@ def render_first_frame_image(
     pre_roll_seconds: int = 0,
     post_roll_seconds: int = 0,
 ):
-    # --- Constantes identiques à celles de generate_gpx_video ---
-    PATCH_FACTOR = 2.4
-    MAX_LARGE_DIM = 4096
-    VERTICAL_BIAS = 0.65
-
     graph_font_size = compute_graph_font_size(FONT_SIZE_MEDIUM)
     try:
         font_large = ImageFont.truetype(font_path, FONT_SIZE_LARGE)
@@ -1789,8 +1807,6 @@ def render_first_frame_image(
 
     lat_min_raw = float(np.min(lats)); lat_max_raw = float(np.max(lats))
     lon_min_raw = float(np.min(lons)); lon_max_raw = float(np.max(lons))
-    lat_c = (lat_min_raw + lat_max_raw) * 0.5
-    lon_c = (lon_min_raw + lon_max_raw) * 0.5
 
     elev_min = float(np.min(interp_eles))
     elev_max = float(np.max(interp_eles))
@@ -1856,21 +1872,22 @@ def render_first_frame_image(
 
         xs_world, ys_world = lonlat_to_pixel_np(interp_lons, interp_lats, zoom)
 
-        x_min = float(np.min(xs_world)); x_max = float(np.max(xs_world))
-        y_min = float(np.min(ys_world)); y_max = float(np.max(ys_world))
-        track_w = x_max - x_min; track_h = y_max - y_min
+        x_min, x_max = float(np.min(xs_world)), float(np.max(xs_world))
+        y_min, y_max = float(np.min(ys_world)), float(np.max(ys_world))
+        cx_px = (x_min + x_max) * 0.5
+        cy_px = (y_min + y_max) * 0.5
 
+        lon_c, lat_c = pixel_to_lonlat(cx_px, cy_px, zoom)
 
         patch_w = int(math.ceil(mw * PATCH_FACTOR))
         patch_h = int(math.ceil(mh * PATCH_FACTOR))
         margin_x = patch_w // 2 + 64
         margin_y = patch_h // 2 + 64
-        width_large = int(min(MAX_LARGE_DIM, max(est_w, track_w + 2 * margin_x)))
-        height_large = int(min(MAX_LARGE_DIM, max(est_h, track_h + 2 * margin_y)))
+        width_large = int(min(MAX_LARGE_DIM, max(mw, (x_max - x_min) + 2 * margin_x)))
+        height_large = int(min(MAX_LARGE_DIM, max(mh, (y_max - y_min) + 2 * margin_y)))
 
-        cx, cy = lonlat_to_pixel(lon_c, lat_c, zoom)
-        x0_world = cx - width_large / 2.0
-        y0_world = cy - height_large / 2.0
+        x0_world = cx_px - width_large / 2.0
+        y0_world = cy_px - height_large / 2.0
 
         try:
             base_map_img_large = render_base_map(
@@ -1879,19 +1896,19 @@ def render_first_frame_image(
         except Exception:
             base_map_img_large = Image.new("RGB", (width_large, height_large), bg_c)
 
-        x_full = xs_world - x0_world
-        y_full = ys_world - y0_world
-        global_xy = np.column_stack((np.rint(x_full).astype(int), np.rint(y_full).astype(int)))
+        xs_local = xs_world - x0_world
+        ys_local = ys_world - y0_world
+        global_xy = np.column_stack((xs_local, ys_local))
         local_xy_buffer = np.empty_like(global_xy)
 
         headings = []
         for i in range(total_frames):
             if i < total_frames - 1:
-                dx = x_full[i + 1] - x_full[i]
-                dy = y_full[i + 1] - y_full[i]
+                dx = xs_local[i + 1] - xs_local[i]
+                dy = ys_local[i + 1] - ys_local[i]
             else:
-                dx = x_full[i] - x_full[i - 1]
-                dy = y_full[i] - y_full[i - 1]
+                dx = xs_local[i] - xs_local[i - 1]
+                dy = ys_local[i] - ys_local[i - 1]
             if abs(dx) > 1e-9 or abs(dy) > 1e-9:
                 headings.append(math.atan2(dx, -dy))
             else:
@@ -1907,8 +1924,8 @@ def render_first_frame_image(
             avg = np.mean(complex_raw[a:b])
             smoothed_angles.append(math.atan2(avg.imag, avg.real))
 
-        xc = float(x_full[current_idx])
-        yc = float(y_full[current_idx])
+        xc = float(xs_local[current_idx])
+        yc = float(ys_local[current_idx])
         patch_left = int(round(xc - patch_w / 2.0))
         patch_top = int(round(yc - patch_h / 2.0))
         patch_img = Image.new("RGB", (patch_w, patch_h), bg_c)
@@ -1926,12 +1943,16 @@ def render_first_frame_image(
         pdraw = ImageDraw.Draw(patch_img)
         np.subtract(global_xy[:, 0], patch_left, out=local_xy_buffer[:, 0])
         np.subtract(global_xy[:, 1], patch_top, out=local_xy_buffer[:, 1])
-        local_xy_list = [(int(pt[0]), int(pt[1])) for pt in local_xy_buffer]
+        local_xy_list = [
+            (int(round(pt[0])), int(round(pt[1]))) for pt in local_xy_buffer
+        ]
         pdraw.line(local_xy_list, fill=map_path_c, width=3)
         pdraw.line(local_xy_list[: current_idx + 1], fill=map_current_path_c, width=4)
         cxp, cyp = local_xy_buffer[current_idx]
         r = 6
-        pdraw.ellipse((int(cxp - r), int(cyp - r), int(cxp + r), int(cyp + r)), fill=map_current_point_c)
+        cxp_i = int(round(cxp))
+        cyp_i = int(round(cyp))
+        pdraw.ellipse((cxp_i - r, cyp_i - r, cxp_i + r, cyp_i + r), fill=map_current_point_c)
 
         speed_kmh0 = float(interp_speeds[current_idx])
         heading_deg = (
@@ -1949,7 +1970,18 @@ def render_first_frame_image(
         view_top = int(round(patch_h / 2.0 - VERTICAL_BIAS * mh))
         view = patch_img.crop((view_left, view_top, view_left + mw, view_top + mh))
 
-        frame_img.paste(view, (int(map_area.get("x", 0)), int(map_area.get("y", 0))))
+        map_x = int(map_area.get("x", 0))
+        map_y = int(map_area.get("y", 0))
+        frame_img.paste(view, (map_x, map_y))
+        if DEBUG_ALIGNMENT:
+            cx_screen = map_x + mw // 2
+            cy_screen = map_y + int(VERTICAL_BIAS * mh)
+            r = 6
+            draw.ellipse(
+                (cx_screen - r, cy_screen - r, cx_screen + r, cy_screen + r),
+                outline=(255, 0, 255),
+                width=2,
+            )
 
         draw_north_arrow(frame_img, map_area, heading_deg, text_c)
 


### PR DESCRIPTION
## Summary
- derive the base map center from WebMercator pixel coordinates and convert back to lon/lat before rendering tiles
- keep local track coordinates in floating point space, recomputing the viewport origin from the pixel-based world origin
- expose VERTICAL_BIAS and DEBUG_ALIGNMENT environment flags and add a debug overlay to validate on-screen alignment

## Testing
- python -m compileall OverlayGPX_V1.py

------
https://chatgpt.com/codex/tasks/task_b_68de3fbb66ac8324a0b1dcfb54961817